### PR TITLE
Fix guest example target path

### DIFF
--- a/examples/guests/build-all.sh
+++ b/examples/guests/build-all.sh
@@ -12,7 +12,7 @@ function build () {
     cd ../..
 
     output_path="examples/hosts/$1/src/guest.polkavm"
-    cargo run -p polkatool link target/riscv32em-unknown-none-elf/release/hello-world-guest -o $output_path
+    cargo run -p polkatool link examples/guests/target/riscv32em-unknown-none-elf/release/$1-guest -o $output_path
 
     echo ">> Program ready in: $(realpath $output_path)"
     stat $output_path | grep -o -E "Size: [0-9]+"


### PR DESCRIPTION
The target path in the build script was pointing to the top level target dir.