### PR TITLE
chore: speed up `read_byte` and `read_extern_fn_prototype`

### DIFF
--- a/crates/polkavm-common/src/elf.rs
+++ b/crates/polkavm-common/src/elf.rs
@@ -19,7 +19,10 @@ impl<'a> Reader<'a> {
     }
 
     pub fn read_byte(&mut self) -> Result<u8, &'static str> {
-        Ok(self.read(1)?[0])
+        let byte = self.buffer.get(0).ok_or("unexpected end of section")?;
+        self.buffer = &self.buffer[1..];
+        self.bytes_consumed += 1;
+        Ok(*byte)
     }
 
     pub fn read_u32(&mut self) -> Result<u32, &'static str> {

--- a/crates/polkavm-common/src/program.rs
+++ b/crates/polkavm-common/src/program.rs
@@ -991,8 +991,8 @@ impl<'a> Reader<'a> {
     }
 
     fn read_byte(&mut self) -> Result<u8, ProgramParseError> {
-        let new_pos = self.position + 1;
-        if let Some(byte) = self.blob.get(new_pos) {
+        if let Some(byte) = self.blob.get(self.position) {
+            let new_pos = self.position + 1;
             self.previous_position = core::mem::replace(&mut self.position, new_pos);
             Ok(*byte)
         } else {


### PR DESCRIPTION
accessing array with range index is expensive than with position index.