### PR TITLE
Enable B extension in CKB-VM's bench programs

### DIFF
--- a/guest-programs/build-benchmarks.sh
+++ b/guest-programs/build-benchmarks.sh
@@ -73,7 +73,7 @@ function build_benchmark() {
 
     if [ "${BUILD_CKBVM}" == "1" ]; then
         echo "> Building: '$1' (CKB VM)"
-        RUSTFLAGS="$extra_flags -C link-arg=-s --cfg=target_ckb_vm" rustup run $TOOLCHAIN_VERSION cargo build -q --target=riscv64imac-unknown-none-elf --release --bin $1 -p $1
+        RUSTFLAGS="$extra_flags -C target-feature=+zba,+zbb,+zbc,+zbs -C link-arg=-s --cfg=target_ckb_vm" rustup run $TOOLCHAIN_VERSION cargo build -q --target=riscv64imac-unknown-none-elf --release --bin $1 -p $1
     fi
 }
 


### PR DESCRIPTION
CKB-VM now has full support for [RISC-V B extension](https://github.com/riscv/riscv-bitmanip), which can be beneficial for certain types of programs.

Here's the benchmark result I gathered on a Ryzen 3900x without B extension:

```
runtime/pinky/polkavm_no_gas: 5907us
runtime/pinky/polkavm_async_gas: 6242us
runtime/pinky/polkavm_sync_gas: 7447us
runtime/pinky/wasmi_stack: 248ms
runtime/pinky/wasmi_register: 159ms
runtime/pinky/wasmtime_cranelift_default: 5914us
runtime/pinky/wasmtime_cranelift_with_fuel: 8409us
runtime/pinky/wasmtime_cranelift_with_epoch: 7182us
runtime/pinky/wasmer: 13ms
runtime/pinky/pvfexecutor: 16ms
runtime/pinky/wasm3: 115ms
runtime/pinky/ckbvm_asm: 137ms
runtime/pinky/ckbvm_non_asm: 1.908s
runtime/pinky/native: 3684us
runtime/prime-sieve/polkavm_no_gas: 2050us
runtime/prime-sieve/polkavm_async_gas: 2177us
runtime/prime-sieve/polkavm_sync_gas: 2201us
runtime/prime-sieve/wasmi_stack: 68ms
runtime/prime-sieve/wasmi_register: 55ms
runtime/prime-sieve/wasmtime_cranelift_default: 1884us
runtime/prime-sieve/wasmtime_cranelift_with_fuel: 2199us
runtime/prime-sieve/wasmtime_cranelift_with_epoch: 2292us
runtime/prime-sieve/wasmer: 5170us
runtime/prime-sieve/pvfexecutor: 5968us
runtime/prime-sieve/wasm3: 32ms
runtime/prime-sieve/ckbvm_asm: 24ms
runtime/prime-sieve/ckbvm_non_asm: 600ms
runtime/prime-sieve/native: 1361us
```

And here's the result with B extension enabled for CKB-VM benchmarks:

```
runtime/pinky/polkavm_no_gas: 5872us
runtime/pinky/polkavm_async_gas: 6142us
runtime/pinky/polkavm_sync_gas: 6953us
runtime/pinky/wasmi_stack: 245ms
runtime/pinky/wasmi_register: 153ms
runtime/pinky/wasmtime_cranelift_default: 5675us
runtime/pinky/wasmtime_cranelift_with_fuel: 8069us
runtime/pinky/wasmtime_cranelift_with_epoch: 6912us
runtime/pinky/wasmer: 13ms
runtime/pinky/pvfexecutor: 15ms
runtime/pinky/wasm3: 110ms
runtime/pinky/ckbvm_asm: 117ms
runtime/pinky/ckbvm_non_asm: 1.677s
runtime/pinky/native: 3566us
runtime/prime-sieve/polkavm_no_gas: 2023us
runtime/prime-sieve/polkavm_async_gas: 2137us
runtime/prime-sieve/polkavm_sync_gas: 2165us
runtime/prime-sieve/wasmi_stack: 66ms
runtime/prime-sieve/wasmi_register: 54ms
runtime/prime-sieve/wasmtime_cranelift_default: 1852us
runtime/prime-sieve/wasmtime_cranelift_with_fuel: 2201us
runtime/prime-sieve/wasmtime_cranelift_with_epoch: 2302us
runtime/prime-sieve/wasmer: 5091us
runtime/prime-sieve/pvfexecutor: 5896us
runtime/prime-sieve/wasm3: 30ms
runtime/prime-sieve/ckbvm_asm: 23ms
runtime/prime-sieve/ckbvm_non_asm: 562ms
runtime/prime-sieve/native: 1332us
```

While prime-sieve only receives minimal speedup, we do get noticeable speedup when running pinky benchmark in CKB-VM(137ms -> 117ms)

BTW: nice work on polkavm! It makes my day seeing more uses of RISC-V in the blockchain world :P