### PR TITLE
Update Wasmi to `v0.32.0-beta.2`

### DIFF
--- a/tools/benchtool/Cargo.toml
+++ b/tools/benchtool/Cargo.toml
@@ -16,7 +16,7 @@ libc = { workspace = true }
 libloading = { version = "0.8.1", optional = true }
 log = { workspace = true }
 object = { version = "0.32.1", default-features = false, features = ["std", "elf"], optional = true }
-wasmi = { git = "https://github.com/paritytech/wasmi.git", rev = "ea3a29ce66ca116489b7bbcec520c5415ace17b2", optional = true }
+wasmi = { version = "0.32.0-beta.2", optional = true }
 
 [target.'cfg(target_arch = "x86_64")'.dependencies]
 ckb-vm = { version = "0.24.6", features = ["asm"], optional = true }

--- a/tools/benchtool/src/backend.rs
+++ b/tools/benchtool/src/backend.rs
@@ -272,9 +272,9 @@ define_backends! {
     Wasm3 => backend_wasm3::Wasm3(),
 
     #[cfg(feature = "wasmi")]
-    Wasmi_StackMachine => backend_wasmi::Wasmi(wasmi::EngineBackend::StackMachine),
+    Wasmi_Eager => backend_wasmi::Wasmi(wasmi::CompilationMode::Eager),
     #[cfg(feature = "wasmi")]
-    Wasmi_RegisterMachine => backend_wasmi::Wasmi(wasmi::EngineBackend::RegisterMachine),
+    Wasmi_Lazy => backend_wasmi::Wasmi(wasmi::CompilationMode::Lazy),
 
     #[cfg(feature = "native")]
     Native => backend_native::Native()
@@ -297,8 +297,8 @@ impl BenchmarkKind {
             BenchmarkKind::WebAssembly => {
                 #[cfg(feature = "wasmi")]
                 {
-                    output.push(BackendKind::Wasmi_StackMachine);
-                    output.push(BackendKind::Wasmi_RegisterMachine);
+                    output.push(BackendKind::Wasmi_Eager);
+                    output.push(BackendKind::Wasmi_Lazy);
                 }
 
                 #[cfg(any(target_arch = "x86_64", target_arch = "aarch64"))]

--- a/tools/benchtool/src/backend/backend_wasmi.rs
+++ b/tools/benchtool/src/backend/backend_wasmi.rs
@@ -1,7 +1,7 @@
 use super::backend_prelude::*;
 
 #[derive(Copy, Clone)]
-pub struct Wasmi(pub wasmi::EngineBackend);
+pub struct Wasmi(pub wasmi::CompilationMode);
 
 pub struct WasmiInstance {
     store: wasmi::Store<()>,
@@ -17,14 +17,15 @@ impl Backend for Wasmi {
 
     fn name(&self) -> &'static str {
         match self.0 {
-            wasmi::EngineBackend::StackMachine => "wasmi_stack",
-            wasmi::EngineBackend::RegisterMachine => "wasmi_register",
+            wasmi::CompilationMode::Eager => "wasmi_eager",
+            wasmi::CompilationMode::LazyTranslation => "wasmi_lazy_translation)",
+            wasmi::CompilationMode::Lazy => "wasmi_lazy",
         }
     }
 
     fn create(&self) -> Self::Engine {
         let mut config = wasmi::Config::default();
-        config.set_engine_backend(self.0);
+        config.compilation_mode(self.0);
         wasmi::Engine::new(&config)
     }
 


### PR DESCRIPTION
Adds `CompilationMode` and removes `EngineBackend` parameter.

```
runtime/minimal/wasmi_eager: 167ns
compilation/minimal/wasmi_eager: 32us
oneshot/minimal/wasmi_eager: 58us

runtime/minimal/wasmi_lazy: 154ns
compilation/minimal/wasmi_lazy: 21us
oneshot/minimal/wasmi_lazy: 53us

runtime/pinky/wasmi_eager: 87ms
compilation/pinky/wasmi_eager: 557us
oneshot/pinky/wasmi_eager: 794ms

runtime/pinky/wasmi_lazy: 87ms
compilation/pinky/wasmi_lazy: 109us
oneshot/pinky/wasmi_lazy: 794ms

runtime/prime-sieve/wasmi_eager: 26ms
compilation/prime-sieve/wasmi_eager: 1109us
oneshot/prime-sieve/wasmi_eager: 276ms

runtime/prime-sieve/wasmi_lazy: 26ms
compilation/prime-sieve/wasmi_lazy: 84us
oneshot/prime-sieve/wasmi_lazy: 269ms
```

Unfortunately I was not able to install the RISC-V toolchain on my MBP M2 via ..
```
rustup toolchain install riscv32em-nightly-2023-04-05-r0-x86_64-unknown-linux-gnu
```