### PR TITLE
explicitly annotate type of `wrap_on_hostcall`

### DIFF
--- a/crates/polkavm/src/compiler.rs
+++ b/crates/polkavm/src/compiler.rs
@@ -450,7 +450,7 @@ impl<S> CompiledInstance<S> where S: SandboxExt {
             }
         }
 
-        let mut on_hostcall = wrap_on_hostcall(on_hostcall);
+        let mut on_hostcall = wrap_on_hostcall::<S>(on_hostcall);
         exec_args.set_on_hostcall(&mut on_hostcall);
 
         let sandbox = self.sandbox.as_mut().unwrap();


### PR DESCRIPTION
`wrap_on_hostcall` has a generic parameter `S`. When calling the function this parameter is instantiated with some inference variable - `_` - Let's call it `?unknown` for now.

When calling `exec_args.set_on_hostcall` we end up equating `for<'r> <S as SandBox>::Access<'r>` with `for<'r> <?unknown as SandBox>::Access<'r>`. This currently constrains `?unknown` to `S`, even though this may not strictly be the case.

There could theoretically exist an impl like
```rust
impl<S: Sandbox> Sandbox for Wrapper<S> {
    type Access<'r> = S::Access<'r>; 
}
```
with this using `wrap_on_hostcall::<Wrapper<S>>(on_hostcall);` would also compile.

Your code previously compiled due to a shortcoming of rustc when handling higher ranked regions. This will be fixed in https://github.com/rust-lang/rust/pull/119849 at which point your code will fail with ambiguity.
