### PR TITLE
Interpreter: Trace log the current instruction

### DIFF
--- a/crates/polkavm/src/interpreter.rs
+++ b/crates/polkavm/src/interpreter.rs
@@ -144,6 +144,7 @@ impl InterpretedInstance {
                 return Err(ExecutionError::Trap(Default::default()));
             };
 
+            visitor.trace_current_instruction(&instruction);
             translate_error(instruction.visit(&mut visitor))?;
             if visitor.inner.return_to_host {
                 break;
@@ -166,6 +167,7 @@ impl InterpretedInstance {
         };
 
         let mut visitor = Visitor { inner: self, ctx };
+        visitor.trace_current_instruction(&instruction);
         instruction.visit(&mut visitor)
     }
 
@@ -632,6 +634,12 @@ impl<'a, 'b> Visitor<'a, 'b> {
         self.inner.nth_basic_block = nth_basic_block;
         self.inner.nth_instruction = nth_instruction;
         self.inner.on_start_new_basic_block()
+    }
+
+    #[inline(always)]
+    fn trace_current_instruction(&self, instruction: &Instruction) {
+        let program_counter = self.inner.nth_instruction;
+        log::trace!("#{program_counter}: {instruction}");
     }
 }
 

--- a/crates/polkavm/src/tracer.rs
+++ b/crates/polkavm/src/tracer.rs
@@ -72,11 +72,9 @@ impl Tracer {
 
         self.trace_current_instruction_source(program_counter);
 
-        let instruction = self.module.instructions()[program_counter as usize];
         if let Some(native_address) = access.native_program_counter() {
+            let instruction = self.module.instructions()[program_counter as usize];
             log::trace!("0x{native_address:x}: #{program_counter}: {instruction}");
-        } else {
-            log::trace!("#{program_counter}: {instruction}");
         }
 
         self.step_crosscheck_interpreter(program_counter)?;


### PR DESCRIPTION
As discussed, we can do it in the interpreter instead of the tracer (we don't care too much about performance now, in the future we can for example make different variants of the interpreter loop)