### PR TITLE
update Wasmi in benchtool

### DIFF
--- a/tools/benchtool/Cargo.toml
+++ b/tools/benchtool/Cargo.toml
@@ -11,7 +11,7 @@ libc = { version = "0.2.149" }
 libloading = { version = "0.8.1", optional = true }
 log = { version = "0.4.20" }
 object = { version = "0.32.1", default-features = false, features = ["std", "elf"], optional = true }
-wasmi = { version = "0.32.0-beta.16", optional = true }
+wasmi = { version = "0.32.0-beta.16", features = ["no-hash-maps"], optional = true }
 polkavm = { path = "../../crates/polkavm" }
 
 [target.'cfg(target_arch = "x86_64")'.dependencies]

--- a/tools/benchtool/src/backend.rs
+++ b/tools/benchtool/src/backend.rs
@@ -278,11 +278,13 @@ define_backends! {
     Wasm3 => backend_wasm3::Wasm3(),
 
     #[cfg(feature = "wasmi")]
-    Wasmi_Eager => backend_wasmi::Wasmi(wasmi::CompilationMode::Eager),
+    Wasmi_Eager => backend_wasmi::Wasmi(backend_wasmi::WasmiConfig::Eager),
     #[cfg(feature = "wasmi")]
-    Wasmi_Lazy => backend_wasmi::Wasmi(wasmi::CompilationMode::Lazy),
+    Wasmi_Lazy => backend_wasmi::Wasmi(backend_wasmi::WasmiConfig::Lazy),
     #[cfg(feature = "wasmi")]
-    Wasmi_LazyTranslation => backend_wasmi::Wasmi(wasmi::CompilationMode::LazyTranslation),
+    Wasmi_Lazy_Unchecked => backend_wasmi::Wasmi(backend_wasmi::WasmiConfig::LazyUnchecked),
+    #[cfg(feature = "wasmi")]
+    Wasmi_LazyTranslation => backend_wasmi::Wasmi(backend_wasmi::WasmiConfig::LazyTranslation),
 
     #[cfg(feature = "native")]
     Native => backend_native::Native()


### PR DESCRIPTION
- Adds `lazy.unchecked` Wasmi configuration since that is used in pallet-contracts for calls
- Enables `no-hash-maps` feature since that is used in pallet-contracts