### PR TITLE
bump `object` crate dependency

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -469,9 +469,9 @@ dependencies = [
 
 [[package]]
 name = "object"
-version = "0.32.1"
+version = "0.36.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9cf5f9dd3933bd50a9e1f149ec995f39ae2c496d31fd772c1fd45ebc27e902b0"
+checksum = "081b846d1d56ddfc18fdf1a922e4f6e07a11768ea1b92dec44e42b72712ccfce"
 dependencies = [
  "memchr",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -48,7 +48,7 @@ iced-x86 = "1.20.0"
 image = { version = "0.24.7", default-features = false }
 libc = "0.2.149"
 log = "0.4.20"
-object = { version = "0.32.1", default-features = false }
+object = { version = "0.36.1", default-features = false }
 proc-macro2 = "1.0.69"
 proptest = "1.3.1"
 quote = "1.0.33"

--- a/crates/polkavm-linker/src/elf.rs
+++ b/crates/polkavm-linker/src/elf.rs
@@ -118,7 +118,7 @@ impl<'data, 'file> Symbol<'data, 'file> {
     }
 
     pub fn kind(&self) -> u8 {
-        self.elf_symbol.raw_symbol().st_type()
+        self.elf_symbol.elf_symbol().st_type()
     }
 }
 
@@ -132,23 +132,23 @@ pub struct Elf<'data> {
 impl<'data> Elf<'data> {
     pub fn parse(data: &'data [u8]) -> Result<Self, ProgramFromElfError> {
         let elf = ElfFile::parse(data)?;
-        if elf.raw_header().e_ident.data != object::elf::ELFDATA2LSB {
+        if elf.elf_header().e_ident.data != object::elf::ELFDATA2LSB {
             return Err(ProgramFromElfError::other("file is not a little endian ELF file"));
         }
 
-        let os_abi = elf.raw_header().e_ident.os_abi;
+        let os_abi = elf.elf_header().e_ident.os_abi;
         if os_abi != object::elf::ELFOSABI_SYSV && os_abi != object::elf::ELFOSABI_GNU {
             return Err(ProgramFromElfError::other("file doesn't use the System V nor GNU ABI"));
         }
 
         if !matches!(
-            elf.raw_header().e_type.get(LittleEndian),
+            elf.elf_header().e_type.get(LittleEndian),
             object::elf::ET_EXEC | object::elf::ET_REL
         ) {
             return Err(ProgramFromElfError::other("file is not a supported ELF file (ET_EXEC or ET_REL)"));
         }
 
-        if elf.raw_header().e_machine.get(LittleEndian) != object::elf::EM_RISCV {
+        if elf.elf_header().e_machine.get(LittleEndian) != object::elf::EM_RISCV {
             return Err(ProgramFromElfError::other("file is not a RISC-V file (EM_RISCV)"));
         }
 

--- a/crates/polkavm-linker/src/program_from_elf.rs
+++ b/crates/polkavm-linker/src/program_from_elf.rs
@@ -5687,8 +5687,10 @@ fn harvest_data_relocations(
             continue;
         };
 
-        let (relocation_name, kind) = match relocation.kind() {
-            object::RelocationKind::Absolute if relocation.encoding() == object::RelocationEncoding::Generic && relocation.size() == 32 => {
+        let (relocation_name, kind) = match (relocation.kind(), relocation.flags()) {
+            (object::RelocationKind::Absolute, _)
+                if relocation.encoding() == object::RelocationEncoding::Generic && relocation.size() == 32 =>
+            {
                 (
                     "R_RISCV_32",
                     Kind::Set(RelocationKind::Abs {
@@ -5697,7 +5699,7 @@ fn harvest_data_relocations(
                     }),
                 )
             }
-            object::RelocationKind::Elf(reloc_kind) => match reloc_kind {
+            (_, object::RelocationFlags::Elf { r_type: reloc_kind }) => match reloc_kind {
                 object::elf::R_RISCV_SET6 => ("R_RISCV_SET6", Kind::Set6 { target }),
                 object::elf::R_RISCV_SUB6 => ("R_RISCV_SUB6", Kind::Sub6 { target }),
                 object::elf::R_RISCV_SET8 => (
@@ -5922,8 +5924,10 @@ fn harvest_code_relocations(
             continue;
         };
 
-        match relocation.kind() {
-            object::RelocationKind::Absolute if relocation.encoding() == object::RelocationEncoding::Generic && relocation.size() == 32 => {
+        match (relocation.kind(), relocation.flags()) {
+            (object::RelocationKind::Absolute, _)
+                if relocation.encoding() == object::RelocationEncoding::Generic && relocation.size() == 32 =>
+            {
                 data_relocations.insert(
                     current_location,
                     RelocationKind::Abs {
@@ -5932,7 +5936,7 @@ fn harvest_code_relocations(
                     },
                 );
             }
-            object::RelocationKind::Elf(reloc_kind) => {
+            (_, object::RelocationFlags::Elf { r_type: reloc_kind }) => {
                 // https://github.com/riscv-non-isa/riscv-elf-psabi-doc/releases
                 match reloc_kind {
                     object::elf::R_RISCV_CALL_PLT => {


### PR DESCRIPTION
Their latest version includes more RISC-V reloc consants which we'll need anyways.