### PR TITLE
add handling of load_imm_and_jump_indirect

### DIFF
--- a/crates/polkavm-common/src/assembler.rs
+++ b/crates/polkavm-common/src/assembler.rs
@@ -377,15 +377,18 @@ pub fn assemble(code: &str) -> Result<Vec<u8>, String> {
                                 emit_and_continue!(MaybeInstruction::LoadImmAndJump(dst, value, label.to_owned()));
                             }
                             if let Some((base, offset)) = parse_indirect_memory_access(line) {
-                                if dst == base {
-                                    return Err(format!("cannot parse line {nth_line}: \"{original_line}\"; hint: use long form."));
-                                }
-                                emit_and_continue!(Instruction::load_imm_and_jump_indirect(
+                                let instruction = Instruction::load_imm_and_jump_indirect(
                                     dst.into(),
                                     base.into(),
                                     value as u32,
                                     offset as u32
-                                ));
+                                );
+                                
+                                if dst == base {
+                                    return Err(format!("cannot parse line {nth_line}, expected: \"{instruction}\""));
+                                }
+
+                                emit_and_continue!(instruction);
                             }
                         }
                     }

--- a/crates/polkavm-common/src/assembler.rs
+++ b/crates/polkavm-common/src/assembler.rs
@@ -37,7 +37,7 @@ fn parse_indirect_memory_access(text: &str) -> Option<(Reg, i32)> {
 
 /// Parses the long form of load_imm_and_jump_indirect:
 /// `tmp = {base}, {dst} = {value}, jump [tmp + {offset}]`, where `dest == base` is allowed
-fn parse_load_imm_and_jump_indirect(line: &str) -> Option<(Reg, Reg, i32, i32)> {
+fn parse_load_imm_and_jump_indirect_with_tmp(line: &str) -> Option<(Reg, Reg, i32, i32)> {
     let line = line.trim().strip_prefix("tmp =")?;
 
     let index = line.find(',')?;

--- a/crates/polkavm-common/src/assembler.rs
+++ b/crates/polkavm-common/src/assembler.rs
@@ -39,10 +39,10 @@ fn parse_indirect_memory_access(text: &str) -> Option<(Reg, i32)> {
 /// `tmp = {base}, {dst} = {value}, jump [tmp + {offset}]`, where `dest == base` is allowed
 fn parse_load_imm_and_jump_indirect_with_tmp(line: &str) -> Option<(Reg, Reg, i32, i32)> {
     let line = line.trim().strip_prefix("tmp")?;
-    if !line.starts_with("=") && line.trim_start() == line {
+    if !line.starts_with('=') && line.trim_start() == line {
         return None;
     }
-    let line = line.trim().strip_prefix("=")?;
+    let line = line.trim().strip_prefix('=')?;
 
     let index = line.find(',')?;
     let base = parse_reg(line[..index].trim())?;

--- a/crates/polkavm-common/src/assembler.rs
+++ b/crates/polkavm-common/src/assembler.rs
@@ -38,7 +38,11 @@ fn parse_indirect_memory_access(text: &str) -> Option<(Reg, i32)> {
 /// Parses the long form of load_imm_and_jump_indirect:
 /// `tmp = {base}, {dst} = {value}, jump [tmp + {offset}]`, where `dest == base` is allowed
 fn parse_load_imm_and_jump_indirect_with_tmp(line: &str) -> Option<(Reg, Reg, i32, i32)> {
-    let line = line.trim().strip_prefix("tmp =")?;
+    let line = line.trim().strip_prefix("tmp")?;
+    if !line.starts_with("=") && line.trim_start() == line {
+        return None;
+    }
+    let line = line.trim().strip_prefix("=")?;
 
     let index = line.find(',')?;
     let base = parse_reg(line[..index].trim())?;

--- a/crates/polkavm-common/src/assembler.rs
+++ b/crates/polkavm-common/src/assembler.rs
@@ -360,7 +360,7 @@ pub fn assemble(code: &str) -> Result<Vec<u8>, String> {
             }
         }
 
-        if let Some((dst, base, value, offset)) = parse_load_imm_and_jump_indirect(line) {
+        if let Some((dst, base, value, offset)) = parse_load_imm_and_jump_indirect_with_tmp(line) {
             emit_and_continue!(Instruction::load_imm_and_jump_indirect(
                 dst.into(),
                 base.into(),
@@ -381,13 +381,9 @@ pub fn assemble(code: &str) -> Result<Vec<u8>, String> {
                                 emit_and_continue!(MaybeInstruction::LoadImmAndJump(dst, value, label.to_owned()));
                             }
                             if let Some((base, offset)) = parse_indirect_memory_access(line) {
-                                let instruction = Instruction::load_imm_and_jump_indirect(
-                                    dst.into(),
-                                    base.into(),
-                                    value as u32,
-                                    offset as u32
-                                );
-                                
+                                let instruction =
+                                    Instruction::load_imm_and_jump_indirect(dst.into(), base.into(), value as u32, offset as u32);
+
                                 if dst == base {
                                     return Err(format!("cannot parse line {nth_line}, expected: \"{instruction}\""));
                                 }

--- a/crates/polkavm-common/src/assembler.rs
+++ b/crates/polkavm-common/src/assembler.rs
@@ -54,7 +54,8 @@ fn parse_load_imm_and_jump_indirect_with_tmp(line: &str) -> Option<(Reg, Reg, i3
 
     let index = line.find(',')?;
     let value = parse_imm(line[..index].trim())?;
-    let text = line[index + 1..].trim().strip_prefix("jump [")?.strip_suffix(']')?;
+    let line = line[index + 1..].trim().strip_prefix("jump")?;
+    let text = line.trim().strip_prefix('[')?.strip_suffix(']')?;
 
     if let Some(index) = text.find('+') {
         if text[..index].trim() != "tmp" {

--- a/crates/polkavm-common/src/assembler.rs
+++ b/crates/polkavm-common/src/assembler.rs
@@ -51,7 +51,7 @@ fn parse_load_imm_and_jump_indirect(line: &str) -> Option<(Reg, Reg, i32, i32)> 
     let index = line.find(',')?;
     let value = parse_imm(line[..index].trim())?;
     let text = line[index + 1..].trim().strip_prefix("jump [")?.strip_suffix(']')?;
-    
+
     if let Some(index) = text.find('+') {
         if text[..index].trim() != "tmp" {
             return None;
@@ -377,6 +377,9 @@ pub fn assemble(code: &str) -> Result<Vec<u8>, String> {
                                 emit_and_continue!(MaybeInstruction::LoadImmAndJump(dst, value, label.to_owned()));
                             }
                             if let Some((base, offset)) = parse_indirect_memory_access(line) {
+                                if dst == base {
+                                    return Err(format!("cannot parse line {nth_line}: \"{original_line}\"; hint: use long form."));
+                                }
                                 emit_and_continue!(Instruction::load_imm_and_jump_indirect(
                                     dst.into(),
                                     base.into(),

--- a/crates/polkavm-common/src/program.rs
+++ b/crates/polkavm-common/src/program.rs
@@ -2086,10 +2086,16 @@ impl<'a, 'b> InstructionVisitor for InstructionFormatter<'a, 'b> {
     fn load_imm_and_jump_indirect(&mut self, ra: RawReg, base: RawReg, value: u32, offset: u32) -> Self::ReturnTy {
         let ra = self.format_reg(ra);
         let base = self.format_reg(base);
-        if !self.format.prefer_unaliased && offset == 0 {
-            write!(self, "jump [{base}], {ra} = {value}")
+        if ra != base {
+            if !self.format.prefer_unaliased && offset == 0 {
+                write!(self, "{ra} = {value}, jump [{base}]")
+            } else {
+                write!(self, "{ra} = {value}, jump [{base} + {offset}]")
+            }
+        } else if !self.format.prefer_unaliased && offset == 0 {
+            write!(self, "tmp = {base}, {ra} = {value}, jump [tmp]")
         } else {
-            write!(self, "jump [{base} + {offset}], {ra} = {value}")
+            write!(self, "tmp = {base} + {offset}, {ra} = {value}, jump [tmp]")
         }
     }
 

--- a/crates/polkavm-common/src/program.rs
+++ b/crates/polkavm-common/src/program.rs
@@ -2095,7 +2095,7 @@ impl<'a, 'b> InstructionVisitor for InstructionFormatter<'a, 'b> {
         } else if !self.format.prefer_unaliased && offset == 0 {
             write!(self, "tmp = {base}, {ra} = {value}, jump [tmp]")
         } else {
-            write!(self, "tmp = {base} + {offset}, {ra} = {value}, jump [tmp]")
+            write!(self, "tmp = {base}, {ra} = {value}, jump [tmp + {offset}]")
         }
     }
 

--- a/tools/spectool/spec/src/inst_load_imm_and_jump_indirect_different_regs_with_offset_ok.txt
+++ b/tools/spectool/spec/src/inst_load_imm_and_jump_indirect_different_regs_with_offset_ok.txt
@@ -1,6 +1,7 @@
 pub @main:
     a0 = @target
-    tmp = a0, a0 = 1234, jump [tmp]
+    a0 = a0 - 100
+    a1 = 1234, jump [a0 + 100]
     trap
 @target:
     a2 = 0xdeadbeef

--- a/tools/spectool/spec/src/inst_load_imm_and_jump_indirect_different_regs_without_offset_ok.txt
+++ b/tools/spectool/spec/src/inst_load_imm_and_jump_indirect_different_regs_without_offset_ok.txt
@@ -3,4 +3,4 @@ pub @main:
     a1 = 1234, jump [a0]
     trap
 @target:
-    a1 = 0xdeadbeef
+    a2 = 0xdeadbeef

--- a/tools/spectool/spec/src/inst_load_imm_and_jump_indirect_different_regs_without_offset_ok.txt
+++ b/tools/spectool/spec/src/inst_load_imm_and_jump_indirect_different_regs_without_offset_ok.txt
@@ -1,0 +1,6 @@
+pub @main:
+    a0 = @target
+    a1 = 1234, jump [a0]
+    trap
+@target:
+    a1 = 0xdeadbeef

--- a/tools/spectool/spec/src/inst_load_imm_and_jump_indirect_invalid_djump_to_zero_different_regs_without_offset_nok.txt
+++ b/tools/spectool/spec/src/inst_load_imm_and_jump_indirect_invalid_djump_to_zero_different_regs_without_offset_nok.txt
@@ -1,0 +1,6 @@
+pub @main:
+pub @expected_exit:
+    a1 = 1234, jump [a0]
+    trap
+@target:
+    a2 = 0xdeadbeef

--- a/tools/spectool/spec/src/inst_load_imm_and_jump_indirect_invalid_djump_to_zero_same_regs_without_offset_nok.txt
+++ b/tools/spectool/spec/src/inst_load_imm_and_jump_indirect_invalid_djump_to_zero_same_regs_without_offset_nok.txt
@@ -1,5 +1,5 @@
 pub @main:
-    a0 = @target
+pub @expected_exit:
     tmp = a0, a0 = 1234, jump [tmp]
     trap
 @target:

--- a/tools/spectool/spec/src/inst_load_imm_and_jump_indirect_misaligned_djump_different_regs_with_offset_nok.txt
+++ b/tools/spectool/spec/src/inst_load_imm_and_jump_indirect_misaligned_djump_different_regs_with_offset_nok.txt
@@ -1,6 +1,7 @@
 pub @main:
     a0 = @target
-    tmp = a0, a0 = 1234, jump [tmp]
+pub @expected_exit:
+    a1 = 1234, jump [a0 + 1]
     trap
 @target:
     a2 = 0xdeadbeef

--- a/tools/spectool/spec/src/inst_load_imm_and_jump_indirect_misaligned_djump_different_regs_without_offset_nok.txt
+++ b/tools/spectool/spec/src/inst_load_imm_and_jump_indirect_misaligned_djump_different_regs_without_offset_nok.txt
@@ -1,6 +1,8 @@
 pub @main:
     a0 = @target
-    tmp = a0, a0 = 1234, jump [tmp]
+    a0 = a0 + 1
+pub @expected_exit:
+    a1 = 1234, jump [a0]
     trap
 @target:
     a2 = 0xdeadbeef

--- a/tools/spectool/spec/src/inst_load_imm_and_jump_indirect_misaligned_djump_same_regs_with_offset_nok.txt
+++ b/tools/spectool/spec/src/inst_load_imm_and_jump_indirect_misaligned_djump_same_regs_with_offset_nok.txt
@@ -1,6 +1,7 @@
 pub @main:
     a0 = @target
-    tmp = a0, a0 = 1234, jump [tmp]
+pub @expected_exit:
+    tmp = a0, a0 = 1234, jump [tmp + 1]
     trap
 @target:
     a2 = 0xdeadbeef

--- a/tools/spectool/spec/src/inst_load_imm_and_jump_indirect_misaligned_djump_same_regs_without_offset_nok.txt
+++ b/tools/spectool/spec/src/inst_load_imm_and_jump_indirect_misaligned_djump_same_regs_without_offset_nok.txt
@@ -1,5 +1,7 @@
 pub @main:
     a0 = @target
+    a0 = a0 + 1
+pub @expected_exit:
     tmp = a0, a0 = 1234, jump [tmp]
     trap
 @target:

--- a/tools/spectool/spec/src/inst_load_imm_and_jump_indirect_same_regs_with_offset_ok.txt
+++ b/tools/spectool/spec/src/inst_load_imm_and_jump_indirect_same_regs_with_offset_ok.txt
@@ -1,6 +1,7 @@
 pub @main:
     a0 = @target
-    tmp = a0, a0 = 1234, jump [tmp]
+    a0 = a0 - 100
+    tmp = a0, a0 = 1234, jump [tmp + 100]
     trap
 @target:
     a2 = 0xdeadbeef

--- a/tools/spectool/spec/src/inst_load_imm_and_jump_indirect_same_regs_without_offset_ok.txt
+++ b/tools/spectool/spec/src/inst_load_imm_and_jump_indirect_same_regs_without_offset_ok.txt
@@ -1,0 +1,6 @@
+pub @main:
+    a0 = @target
+    tmp = a0, a0 = 1234, jump [tmp]
+    trap
+@target:
+    a1 = 0xdeadbeef


### PR DESCRIPTION
Adds support for `load_imm_and_jump_indirect`:
  - short form: `a1 = 1234, jump [a0]`
  - long form: `tmp = a0, a0 = 1234, jump [tmp]`

Short form is only accepted if the two passed registers are not the same. For the case that they are, only the long form is accepted. The outputted disassembly also follows this rule. When writing assembly, the long form will always be accepted.