### PR TITLE
Format code of modules declared in macros too

### DIFF
--- a/ci/jobs/rustfmt.sh
+++ b/ci/jobs/rustfmt.sh
@@ -6,6 +6,8 @@ cd ../..
 
 echo ">> cargo fmt"
 cargo fmt --check --all
+# https://github.com/rust-lang/rustfmt/issues/3253
+cargo fmt --check -- $(find crates/polkavm -name *.rs)
 
 echo ">> cargo fmt (zygote)"
 cd crates/polkavm-zygote

--- a/crates/polkavm/src/bit_mask.rs
+++ b/crates/polkavm/src/bit_mask.rs
@@ -1,15 +1,16 @@
 #![allow(clippy::same_name_method)]
 
-pub trait RawMask: Copy +
-    core::ops::BitOrAssign<Self> +
-    core::ops::BitAndAssign<Self> +
-    core::ops::Shl<u32, Output = Self> +
-    core::ops::Sub<Output = Self> +
-    core::ops::BitAnd<Output = Self> +
-    core::ops::Not<Output = Self> +
-    PartialEq +
-    Eq +
-    core::fmt::Debug
+pub trait RawMask:
+    Copy
+    + core::ops::BitOrAssign<Self>
+    + core::ops::BitAndAssign<Self>
+    + core::ops::Shl<u32, Output = Self>
+    + core::ops::Sub<Output = Self>
+    + core::ops::BitAnd<Output = Self>
+    + core::ops::Not<Output = Self>
+    + PartialEq
+    + Eq
+    + core::fmt::Debug
 {
     const ZERO: Self;
     const ONE: Self;
@@ -78,7 +79,11 @@ impl<Primary, Secondary> BitIndex<Primary, Secondary> {
 
 /// A constant-length two-level bitmask.
 #[derive(Debug)]
-pub struct BitMask<Primary, Secondary, const SECONDARY_LENGTH: usize> where Primary: RawMask, Secondary: RawMask {
+pub struct BitMask<Primary, Secondary, const SECONDARY_LENGTH: usize>
+where
+    Primary: RawMask,
+    Secondary: RawMask,
+{
     /// The primary mask. This mask is used to mark which secondary masks are non-empty.
     primary_mask: Primary,
 
@@ -152,14 +157,22 @@ fn test_bitmask_out_of_range() {
     mask.set(Mask16::index(16));
 }
 
-impl<Primary, Secondary, const SECONDARY_LENGTH: usize> Default for BitMask<Primary, Secondary, SECONDARY_LENGTH> where Primary: RawMask, Secondary: RawMask {
+impl<Primary, Secondary, const SECONDARY_LENGTH: usize> Default for BitMask<Primary, Secondary, SECONDARY_LENGTH>
+where
+    Primary: RawMask,
+    Secondary: RawMask,
+{
     #[inline]
     fn default() -> Self {
         Self::new()
     }
 }
 
-impl<Primary, Secondary, const SECONDARY_LENGTH: usize> BitMask<Primary, Secondary, SECONDARY_LENGTH> where Primary: RawMask, Secondary: RawMask {
+impl<Primary, Secondary, const SECONDARY_LENGTH: usize> BitMask<Primary, Secondary, SECONDARY_LENGTH>
+where
+    Primary: RawMask,
+    Secondary: RawMask,
+{
     const PRIMARY_BIN_SHIFT: u32 = (core::mem::size_of::<Secondary>() * 8).ilog2();
     const SECONDARY_BIN_MASK: u32 = (1 << Self::PRIMARY_BIN_SHIFT) - 1;
 

--- a/crates/polkavm/src/generic_allocator.rs
+++ b/crates/polkavm/src/generic_allocator.rs
@@ -71,7 +71,10 @@ pub struct AllocatorBinConfig {
 }
 
 #[doc(hidden)]
-pub const fn calculate_optimal_bin_config<PrimaryMask, SecondaryMask>(max_allocation_size: u32, mut requested_max_bins: u32) -> AllocatorBinConfig {
+pub const fn calculate_optimal_bin_config<PrimaryMask, SecondaryMask>(
+    max_allocation_size: u32,
+    mut requested_max_bins: u32,
+) -> AllocatorBinConfig {
     let true_max_bins = (core::mem::size_of::<PrimaryMask>() * 8 * ::core::mem::size_of::<SecondaryMask>() * 8) as u32;
     if true_max_bins < requested_max_bins {
         requested_max_bins = true_max_bins
@@ -148,14 +151,22 @@ trait BitMaskT: Default {
     fn find_first(&mut self, min_index: Self::Index) -> Option<Self::Index>;
 }
 
-impl<Primary, Secondary> BitIndexT for crate::bit_mask::BitIndex<Primary, Secondary> where Primary: Copy, Secondary: Copy {
+impl<Primary, Secondary> BitIndexT for crate::bit_mask::BitIndex<Primary, Secondary>
+where
+    Primary: Copy,
+    Secondary: Copy,
+{
     #[inline]
     fn index(&self) -> usize {
         Self::index(self)
     }
 }
 
-impl<Primary, Secondary, const SECONDARY_LENGTH: usize> BitMaskT for crate::bit_mask::BitMask<Primary, Secondary, SECONDARY_LENGTH> where Primary: crate::bit_mask::RawMask, Secondary: crate::bit_mask::RawMask {
+impl<Primary, Secondary, const SECONDARY_LENGTH: usize> BitMaskT for crate::bit_mask::BitMask<Primary, Secondary, SECONDARY_LENGTH>
+where
+    Primary: crate::bit_mask::RawMask,
+    Secondary: crate::bit_mask::RawMask,
+{
     type Index = crate::bit_mask::BitIndex<Primary, Secondary>;
 
     #[inline]
@@ -207,15 +218,21 @@ macro_rules! _allocator_config {
     ) => {
         impl $crate::generic_allocator::AllocatorConfig for $type {
             const MAX_ALLOCATION_SIZE: u32 = $max_allocation_size;
-            type BitMask = $crate::bit_mask::bitmask_type!(usize, usize, $crate::generic_allocator::calculate_optimal_bin_config::<usize, usize>($max_allocation_size, $max_bins).bin_count as usize);
-            type BinArray = [u32; $crate::generic_allocator::calculate_optimal_bin_config::<usize, usize>($max_allocation_size, $max_bins).bin_count as usize];
+            type BitMask = $crate::bit_mask::bitmask_type!(
+                usize,
+                usize,
+                $crate::generic_allocator::calculate_optimal_bin_config::<usize, usize>($max_allocation_size, $max_bins).bin_count as usize
+            );
+            type BinArray = [u32; $crate::generic_allocator::calculate_optimal_bin_config::<usize, usize>($max_allocation_size, $max_bins)
+                .bin_count as usize];
 
             fn to_bin_index<const ROUND_UP: bool>(size: u32) -> u32 {
-                const MANTISSA_BITS: u32 = $crate::generic_allocator::calculate_optimal_bin_config::<usize, usize>($max_allocation_size, $max_bins).mantissa_bits;
+                const MANTISSA_BITS: u32 =
+                    $crate::generic_allocator::calculate_optimal_bin_config::<usize, usize>($max_allocation_size, $max_bins).mantissa_bits;
                 $crate::generic_allocator::to_bin_index::<MANTISSA_BITS, ROUND_UP>(size)
             }
         }
-    }
+    };
 }
 
 pub use _allocator_config as allocator_config;
@@ -268,7 +285,10 @@ impl GenericAllocation {
     }
 }
 
-impl<C> GenericAllocator<C> where C: AllocatorConfig {
+impl<C> GenericAllocator<C>
+where
+    C: AllocatorConfig,
+{
     pub fn new(total_space: u32) -> Self {
         let mut mutable = GenericAllocator {
             bins_with_free_space: C::BitMask::default(),
@@ -394,11 +414,7 @@ impl<C> GenericAllocator<C> where C: AllocatorConfig {
             self.nodes[new_free_node as usize].next_by_address = next_by_address;
         }
 
-        Some(GenericAllocation {
-            node,
-            offset,
-            size
-        })
+        Some(GenericAllocation { node, offset, size })
     }
 
     pub fn free(&mut self, alloc: GenericAllocation) {
@@ -406,7 +422,11 @@ impl<C> GenericAllocator<C> where C: AllocatorConfig {
             return;
         }
 
-        let GenericAllocation { node, mut offset, mut size } = alloc;
+        let GenericAllocation {
+            node,
+            mut offset,
+            mut size,
+        } = alloc;
 
         // Check if there's a free node before this node with which we can merge.
         {

--- a/crates/polkavm/src/sandbox.rs
+++ b/crates/polkavm/src/sandbox.rs
@@ -1,19 +1,15 @@
 use alloc::sync::Arc;
 use core::sync::atomic::{AtomicUsize, Ordering};
 
-use polkavm_common::{
-    zygote::{
-        AddressTable,
-    },
-};
+use polkavm_common::zygote::AddressTable;
 
-use crate::{Gas, InterruptKind, Reg, RegValue, MemoryAccessError, AsUninitSliceMut, ProgramCounter};
 use crate::api::{EngineState, Module};
 use crate::compiler::CompiledModule;
 use crate::config::{Config, SandboxKind};
+use crate::error::Error;
 use crate::mutex::Mutex;
 use crate::utils::GuestInit;
-use crate::error::Error;
+use crate::{AsUninitSliceMut, Gas, InterruptKind, MemoryAccessError, ProgramCounter, Reg, RegValue};
 
 macro_rules! get_field_offset {
     ($struct:expr, |$struct_ident:ident| $get_field:expr) => {{
@@ -23,7 +19,7 @@ macro_rules! get_field_offset {
         let struct_addr = struct_ref as usize;
         let field_addr = field_ptr as usize;
         field_addr - struct_addr
-    }}
+    }};
 }
 
 #[cfg(feature = "generic-sandbox")]
@@ -107,7 +103,11 @@ pub(crate) trait Sandbox: Sized {
     fn allocate_jump_table(global: &Self::GlobalState, count: usize) -> Result<Self::JumpTable, Self::Error>;
 
     fn reserve_address_space() -> Result<Self::AddressSpace, Self::Error>;
-    fn prepare_program(global: &Self::GlobalState, init: SandboxInit<Self>, address_space: Self::AddressSpace) -> Result<Self::Program, Self::Error>;
+    fn prepare_program(
+        global: &Self::GlobalState,
+        init: SandboxInit<Self>,
+        address_space: Self::AddressSpace,
+    ) -> Result<Self::Program, Self::Error>;
     fn spawn(global: &Self::GlobalState, config: &Self::Config) -> Result<Self, Self::Error>;
     fn load_module(&mut self, global: &Self::GlobalState, module: &Module) -> Result<(), Self::Error>;
     fn recycle(&mut self, global: &Self::GlobalState) -> Result<(), Self::Error>;
@@ -125,7 +125,9 @@ pub(crate) trait Sandbox: Sized {
     fn next_native_program_counter(&self) -> Option<usize>;
     fn set_next_program_counter(&mut self, pc: ProgramCounter);
     fn reset_memory(&mut self) -> Result<(), Self::Error>;
-    fn read_memory_into<'slice, B>(&self, address: u32, buffer: &'slice mut B) -> Result<&'slice mut [u8], MemoryAccessError> where B: ?Sized + AsUninitSliceMut;
+    fn read_memory_into<'slice, B>(&self, address: u32, buffer: &'slice mut B) -> Result<&'slice mut [u8], MemoryAccessError>
+    where
+        B: ?Sized + AsUninitSliceMut;
     fn write_memory(&mut self, address: u32, data: &[u8]) -> Result<(), MemoryAccessError>;
     fn zero_memory(&mut self, address: u32, length: u32) -> Result<(), MemoryAccessError>;
     fn free_pages(&mut self, address: u32, length: u32) -> Result<(), Self::Error>;
@@ -135,7 +137,10 @@ pub(crate) trait Sandbox: Sized {
 }
 
 #[derive(Copy, Clone, Default)]
-pub struct SandboxInit<'a, S> where S: Sandbox {
+pub struct SandboxInit<'a, S>
+where
+    S: Sandbox,
+{
     pub guest_init: GuestInit<'a>,
     pub code: &'a [u8],
     pub jump_table: S::JumpTable,
@@ -143,12 +148,18 @@ pub struct SandboxInit<'a, S> where S: Sandbox {
     pub sysreturn_address: u64,
 }
 
-pub(crate) struct SandboxInstance<S> where S: Sandbox {
+pub(crate) struct SandboxInstance<S>
+where
+    S: Sandbox,
+{
     engine_state: Arc<EngineState>,
-    sandbox: Option<S>
+    sandbox: Option<S>,
 }
 
-impl<S> SandboxInstance<S> where S: Sandbox {
+impl<S> SandboxInstance<S>
+where
+    S: Sandbox,
+{
     pub fn spawn_and_load_module(engine_state: Arc<EngineState>, module: &Module) -> Result<Self, Error> {
         use crate::sandbox::SandboxConfig;
 
@@ -156,7 +167,11 @@ impl<S> SandboxInstance<S> where S: Sandbox {
         sandbox_config.enable_logger(is_sandbox_logging_enabled());
 
         let global = S::downcast_global_state(engine_state.sandbox_global.as_ref().unwrap());
-        let mut sandbox = if let Some(sandbox) = engine_state.sandbox_cache.as_ref().and_then(|cache| S::downcast_worker_cache(cache).reuse_sandbox()) {
+        let mut sandbox = if let Some(sandbox) = engine_state
+            .sandbox_cache
+            .as_ref()
+            .and_then(|cache| S::downcast_worker_cache(cache).reuse_sandbox())
+        {
             sandbox
         } else {
             S::spawn(global, &sandbox_config)
@@ -164,8 +179,8 @@ impl<S> SandboxInstance<S> where S: Sandbox {
                 .map_err(|error| error.context("instantiation failed: failed to create a sandbox"))?
         };
 
-
-        sandbox.load_module(global, module)
+        sandbox
+            .load_module(global, module)
             .map_err(Error::from_display)
             .map_err(|error| error.context("instantiation failed: failed to upload the program into the sandbox"))?;
 
@@ -184,7 +199,10 @@ impl<S> SandboxInstance<S> where S: Sandbox {
     }
 }
 
-impl<S> Drop for SandboxInstance<S> where S: Sandbox {
+impl<S> Drop for SandboxInstance<S>
+where
+    S: Sandbox,
+{
     fn drop(&mut self) {
         if let Some(cache) = self.engine_state.sandbox_cache.as_ref() {
             let cache = S::downcast_worker_cache(cache);
@@ -215,18 +233,24 @@ impl GlobalStateKind {
             SandboxKind::Linux => {
                 #[cfg(target_os = "linux")]
                 {
-                    Ok(Self::Linux(crate::sandbox::linux::GlobalState::new(config).map_err(|error| format!("failed to initialize Linux sandbox: {error}"))?))
+                    Ok(Self::Linux(
+                        crate::sandbox::linux::GlobalState::new(config)
+                            .map_err(|error| format!("failed to initialize Linux sandbox: {error}"))?,
+                    ))
                 }
 
                 #[cfg(not(target_os = "linux"))]
                 {
                     unreachable!()
                 }
-            },
+            }
             SandboxKind::Generic => {
                 #[cfg(feature = "generic-sandbox")]
                 {
-                    Ok(Self::Generic(crate::sandbox::generic::GlobalState::new(config).map_err(|error| format!("failed to initialize generic sandbox: {error}"))?))
+                    Ok(Self::Generic(
+                        crate::sandbox::generic::GlobalState::new(config)
+                            .map_err(|error| format!("failed to initialize generic sandbox: {error}"))?,
+                    ))
                 }
 
                 #[cfg(not(feature = "generic-sandbox"))]
@@ -258,7 +282,7 @@ impl WorkerCacheKind {
                 {
                     unreachable!()
                 }
-            },
+            }
             SandboxKind::Generic => {
                 #[cfg(feature = "generic-sandbox")]
                 {
@@ -276,9 +300,7 @@ impl WorkerCacheKind {
     pub(crate) fn spawn(&self, global: &GlobalStateKind) -> Result<(), Error> {
         match self {
             #[cfg(target_os = "linux")]
-            WorkerCacheKind::Linux(ref cache) => {
-                cache.spawn(crate::sandbox::linux::Sandbox::downcast_global_state(global))
-            },
+            WorkerCacheKind::Linux(ref cache) => cache.spawn(crate::sandbox::linux::Sandbox::downcast_global_state(global)),
             #[cfg(feature = "generic-sandbox")]
             WorkerCacheKind::Generic(ref cache) => cache.spawn(crate::sandbox::generic::Sandbox::downcast_global_state(global)),
         }
@@ -291,7 +313,10 @@ pub(crate) struct WorkerCache<S> {
     worker_limit: usize,
 }
 
-impl<S> WorkerCache<S> where S: Sandbox {
+impl<S> WorkerCache<S>
+where
+    S: Sandbox,
+{
     pub(crate) fn new(config: &Config) -> Self {
         WorkerCache {
             sandboxes: Mutex::new(Vec::new()),
@@ -306,7 +331,12 @@ impl<S> WorkerCache<S> where S: Sandbox {
 
         let sandbox = S::spawn(global, &sandbox_config)
             .map_err(crate::Error::from_display)
-            .map_err(|error| error.context(format!("failed to create a worker process ({} already exist)", self.available_workers.load(Ordering::Relaxed))))?;
+            .map_err(|error| {
+                error.context(format!(
+                    "failed to create a worker process ({} already exist)",
+                    self.available_workers.load(Ordering::Relaxed)
+                ))
+            })?;
 
         let mut sandboxes = self.sandboxes.lock();
         sandboxes.push(sandbox);
@@ -343,7 +373,10 @@ impl<S> WorkerCache<S> where S: Sandbox {
         }
 
         loop {
-            if let Err(new_count) = self.available_workers.compare_exchange(count, count + 1, Ordering::Relaxed, Ordering::Relaxed) {
+            if let Err(new_count) = self
+                .available_workers
+                .compare_exchange(count, count + 1, Ordering::Relaxed, Ordering::Relaxed)
+            {
                 if new_count >= self.worker_limit {
                     return;
                 }

--- a/crates/polkavm/src/shm_allocator.rs
+++ b/crates/polkavm/src/shm_allocator.rs
@@ -1,10 +1,10 @@
 #![allow(clippy::undocumented_unsafe_blocks)]
 
-use alloc::sync::Arc;
-use polkavm_linux_raw as linux_raw;
-use linux_raw::{cstr, Fd, Error};
 use crate::mutex::Mutex;
 use crate::sandbox::get_native_page_size;
+use alloc::sync::Arc;
+use linux_raw::{cstr, Error, Fd};
+use polkavm_linux_raw as linux_raw;
 
 use crate::generic_allocator::{GenericAllocation, GenericAllocator};
 
@@ -39,10 +39,7 @@ impl ShmAllocation {
     ///
     /// The allocation must not be already mutably borrowed.
     pub unsafe fn as_slice(&self) -> &[u8] {
-        core::slice::from_raw_parts(
-            self.as_ptr(),
-            self.len()
-        )
+        core::slice::from_raw_parts(self.as_ptr(), self.len())
     }
 
     /// Accesses the allocation as a mutable slice.
@@ -52,10 +49,7 @@ impl ShmAllocation {
     /// The allocation must not be already immutably or mutably borrowed.
     #[allow(clippy::mut_from_ref)]
     pub unsafe fn as_slice_mut(&self) -> &mut [u8] {
-        core::slice::from_raw_parts_mut(
-            self.as_mut_ptr(),
-            self.len()
-        )
+        core::slice::from_raw_parts_mut(self.as_mut_ptr(), self.len())
     }
 
     /// Accesses the allocation as a mutable slice of a given type.
@@ -68,10 +62,7 @@ impl ShmAllocation {
     ///   or `T` cannot have any niches.
     #[allow(clippy::mut_from_ref)]
     pub unsafe fn as_typed_slice_mut<T>(&self) -> &mut [T] {
-        core::slice::from_raw_parts_mut(
-            self.as_mut_ptr().cast(),
-            self.len() / core::mem::size_of::<T>()
-        )
+        core::slice::from_raw_parts_mut(self.as_mut_ptr().cast(), self.len() / core::mem::size_of::<T>())
     }
 
     pub fn offset(&self) -> usize {
@@ -80,13 +71,23 @@ impl ShmAllocation {
 
     pub fn as_ptr(&self) -> *const u8 {
         unsafe {
-            self.allocator.0.mmap.as_ptr().cast::<u8>().add((self.allocation.offset() << self.allocator.0.page_shift) as usize)
+            self.allocator
+                .0
+                .mmap
+                .as_ptr()
+                .cast::<u8>()
+                .add((self.allocation.offset() << self.allocator.0.page_shift) as usize)
         }
     }
 
     pub fn as_mut_ptr(&self) -> *mut u8 {
         unsafe {
-            self.allocator.0.mmap.as_mut_ptr().cast::<u8>().add((self.allocation.offset() << self.allocator.0.page_shift) as usize)
+            self.allocator
+                .0
+                .mmap
+                .as_mut_ptr()
+                .cast::<u8>()
+                .add((self.allocation.offset() << self.allocator.0.page_shift) as usize)
         }
     }
 
@@ -119,14 +120,16 @@ impl ShmAllocator {
         let fd = linux_raw::sys_memfd_create(cstr!("global"), linux_raw::MFD_CLOEXEC | linux_raw::MFD_ALLOW_SEALING)?;
         linux_raw::sys_ftruncate(fd.borrow(), linux_raw::c_ulong::from(u32::MAX))?;
 
-        let mmap = unsafe { linux_raw::Mmap::map(
-            core::ptr::null_mut(),
-            u32::MAX as usize,
-            linux_raw::PROT_READ | linux_raw::PROT_WRITE,
-            linux_raw::MAP_SHARED,
-            Some(fd.borrow()),
-            0,
-        )? };
+        let mmap = unsafe {
+            linux_raw::Mmap::map(
+                core::ptr::null_mut(),
+                u32::MAX as usize,
+                linux_raw::PROT_READ | linux_raw::PROT_WRITE,
+                linux_raw::MAP_SHARED,
+                Some(fd.borrow()),
+                0,
+            )?
+        };
 
         linux_raw::sys_fcntl(
             fd.borrow(),
@@ -138,7 +141,7 @@ impl ShmAllocator {
             page_shift,
             mmap,
             fd,
-            mutable: Mutex::new(GenericAllocator::<Config>::new(u32::MAX >> page_shift))
+            mutable: Mutex::new(GenericAllocator::<Config>::new(u32::MAX >> page_shift)),
         })))
     }
 


### PR DESCRIPTION
`rustfmt` [doesn't format modules declared in macros](https://github.com/rust-lang/rustfmt/issues/3253).