### PR TITLE
uffd: io_uring can bubble up ERESTARTSYS

### DIFF
--- a/crates/polkavm-linux-raw/src/arch_amd64_bindings.rs
+++ b/crates/polkavm-linux-raw/src/arch_amd64_bindings.rs
@@ -1199,6 +1199,7 @@ pub const ERANGE: u32 = 34;
 pub const EOPNOTSUPP: u32 = 95;
 pub const ETOOMANYREFS: u32 = 109;
 pub const ETIMEDOUT: u32 = 110;
+pub const ERESTARTSYS: u32 = 512;
 pub const FUTEX_WAIT: u32 = 0;
 pub const FUTEX_WAKE: u32 = 1;
 pub const FUTEX_FD: u32 = 2;

--- a/crates/polkavm-linux-raw/src/lib.rs
+++ b/crates/polkavm-linux-raw/src/lib.rs
@@ -209,6 +209,7 @@ pub use crate::arch_bindings::{
     ETOOMANYREFS,
     ETXTBSY,
     EXDEV,
+    ERESTARTSYS,
     F_ADD_SEALS,
     F_DUPFD,
     F_GETFD,
@@ -1310,6 +1311,7 @@ impl Error {
             ERANGE => Some("ERANGE"),
             EOPNOTSUPP => Some("EOPNOTSUPP"),
             ETOOMANYREFS => Some("ETOOMANYREFS"),
+            ERESTARTSYS => Some("ERESTARTSYS"),
             _ => None,
         };
 

--- a/crates/polkavm/src/sandbox/linux.rs
+++ b/crates/polkavm/src/sandbox/linux.rs
@@ -2163,9 +2163,12 @@ impl Sandbox {
                     if job.user_data == IO_URING_JOB_FUTEX_WAIT {
                         self.iouring_futex_wait_queued = false;
                     } else if job.user_data == IO_URING_JOB_USERFAULTFD_READ {
+                        self.iouring_uffd_read_queued = false;
+                        if job.res == -(linux_raw::ERESTARTSYS as i32) {
+                            continue 'outer;
+                        }
                         job.to_result()?;
 
-                        self.iouring_uffd_read_queued = false;
                         let msg = unsafe { &mut *self.uffd_msg.0.get() };
                         let event = u32::from(core::mem::replace(&mut msg.event, 0));
                         if event == linux_raw::UFFD_EVENT_PAGEFAULT {


### PR DESCRIPTION
On `Linux 6.10.5-arch1-1`  I see this bubbling up and many dynamic paging tests fail as a result. In that case, just retrying fixes the test suite.