### PR TITLE
Always open logging pipe with child

### DIFF
--- a/crates/polkavm/src/sandbox/linux.rs
+++ b/crates/polkavm/src/sandbox/linux.rs
@@ -1156,7 +1156,7 @@ impl super::Sandbox for Sandbox {
         })))
     }
 
-    fn spawn(global: &Self::GlobalState, config: &SandboxConfig) -> Result<Self, Error> {
+    fn spawn(global: &Self::GlobalState, _config: &SandboxConfig) -> Result<Self, Error> {
         let sigset = Sigmask::block_all_signals()?;
         let (vmctx_memfd, vmctx_mmap) = prepare_vmctx()?;
         let (socket, child_socket) = linux_raw::sys_socketpair(linux_raw::AF_UNIX, linux_raw::SOCK_SEQPACKET | linux_raw::SOCK_CLOEXEC, 0)?;


### PR DESCRIPTION
On `Linux 6.10.5-arch1-1` the hello world example with uffd enabled only works with logs enabled (without the logging pipe set up, the child traps during spawn if dynamic paging is enabled).

I noticed that the zygote does write all logs regardless of the log level, so it should be fine to have the pipe even without logging since the sandbox  filters them according to log level anyways.

This PR together with #154 fixes the hello world example with dynamic paging.