### PR TITLE
refactor: change to the official riscv32emac toolchain

### DIFF
--- a/crates/polkavm-linker/Cargo.toml
+++ b/crates/polkavm-linker/Cargo.toml
@@ -1,3 +1,7 @@
+[features]
+default = []
+dwarf = []
+
 [package]
 name = "polkavm-linker"
 version.workspace = true

--- a/crates/polkavm-linker/src/dwarf.rs
+++ b/crates/polkavm-linker/src/dwarf.rs
@@ -1815,12 +1815,10 @@ struct LineEntry {
     location: SourceCodeLocation,
 }
 
+/// Represents a DWARF section. This is not the most efficient representation,
+/// but it's invariant to any transformations that might be applied to the code.
 #[derive(Default)]
-pub(crate) struct DwarfInfo {
-    // This is not the most efficient representation, but it's invariant
-    // to any transformations that might be applied to the code.
-    pub location_map: HashMap<SectionTarget, Arc<[Location]>>,
-}
+pub(crate) struct DwarfInfo(pub HashMap<SectionTarget, Arc<[Location]>>);
 
 struct AttributeValue<R>
 where
@@ -2241,7 +2239,7 @@ where
     Ok(None)
 }
 
-pub(crate) fn load_dwarf<H>(
+pub(crate) fn load<H>(
     string_cache: &mut StringCache,
     elf: &Elf<H>,
     relocations: &BTreeMap<SectionTarget, RelocationKind>,
@@ -2329,5 +2327,5 @@ where
     };
 
     let location_map = walker.run()?;
-    Ok(DwarfInfo { location_map })
+    Ok(DwarfInfo(location_map))
 }

--- a/crates/polkavm-linker/src/program_from_elf.rs
+++ b/crates/polkavm-linker/src/program_from_elf.rs
@@ -8311,8 +8311,9 @@ where
     let mut location_map: HashMap<SectionTarget, Arc<[Location]>> = HashMap::new();
     if !config.strip {
         let mut string_cache = crate::utils::StringCache::default();
-        let dwarf_info = crate::dwarf::load_dwarf(&mut string_cache, &elf, &relocations)?;
-        location_map = dwarf_info.location_map;
+        if cfg!(feature = "dwarf") {
+            location_map = (crate::dwarf::load(&mut string_cache, &elf, &relocations)?).0;
+        }
 
         // If there is no DWARF info present try to use the symbol table as a fallback.
         for (source, name) in parse_function_symbols(&elf)? {

--- a/guest-programs/.cargo/config.toml
+++ b/guest-programs/.cargo/config.toml
@@ -1,7 +1,7 @@
 [build]
-target = "riscv32ema-unknown-none-elf"
+target = "riscv32emac-unknown-none-polkavm"
 
-[target.riscv32ema-unknown-none-elf]
+[target.riscv32emac-unknown-none-polkavm]
 rustflags = [
     "-C", "relocation-model=pie",
     "-C", "link-arg=--emit-relocs",

--- a/guest-programs/build-benchmarks.sh
+++ b/guest-programs/build-benchmarks.sh
@@ -1,13 +1,9 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 set -euo pipefail
 cd -- "$(dirname -- "${BASH_SOURCE[0]}")"
 
 source ../ci/jobs/detect-or-install-riscv-toolchain.sh
-
-if [ "${RV32E_TOOLCHAIN:-}" == "" ]; then
-    echo "WARN: rv32e toolchain is missing; PolkaVM binaries won't be built!"
-fi
 
 TOOLCHAIN_VERSION="1.75.0"
 
@@ -71,17 +67,27 @@ if [ "${SOLANA_PLATFORM_TOOLS_DIR:-}" == "" ]; then
     esac
 fi
 
+build_polkavm() {
+    echo "> Building: '$1' (polkavm)"
+
+    RUSTFLAGS="$extra_flags" cargo build -Z build-std=core,alloc \
+        --target "$PWD/riscv32emac-unknown-none-polkavm.json" \
+        -q --release --bin $1 -p $1
+
+    pushd ..
+
+    cargo run -q -p polkatool link \
+        --run-only-if-newer guest-programs/target/riscv32emac-unknown-none-polkavm/release/$1 \
+        -o guest-programs/target/riscv32emac-unknown-none-polkavm/release/$1.polkavm
+
+    popd
+}
+
 function build_benchmark() {
-    current_dir=$(pwd)
     extra_flags="${extra_flags:-}"
 
-    if [ "${RV32E_TOOLCHAIN:-}" != "" ]; then
-        echo "> Building: '$1' (polkavm)"
-        RUSTFLAGS="-C target-feature=+lui-addi-fusion,+fast-unaligned-access,+xtheadcondmov,+c -C relocation-model=pie -C link-arg=--emit-relocs -C link-arg=--unique $extra_flags" rustup run $RV32E_TOOLCHAIN cargo build -q --release --bin $1 -p $1
-        cd ..
-        cargo run -q -p polkatool link --run-only-if-newer guest-programs/target/riscv32ema-unknown-none-elf/release/$1 -o guest-programs/target/riscv32ema-unknown-none-elf/release/$1.polkavm
-        cd $current_dir
-    fi
+    # Unconditional build:
+    build_polkavm $1
 
     if [ "${BUILD_WASM}" == "1" ]; then
         echo "> Building: '$1' (wasm)"

--- a/guest-programs/riscv32emac-unknown-none-polkavm.json
+++ b/guest-programs/riscv32emac-unknown-none-polkavm.json
@@ -1,0 +1,26 @@
+{
+  "arch": "riscv32",
+  "cpu": "generic-rv32",
+  "crt-objects-fallback": "false",
+  "data-layout": "e-m:e-p:32:32-i64:64-n32-S32",
+  "eh-frame-header": false,
+  "emit-debug-gdb-scripts": false,
+  "features": "+e,+m,+a,+c,+lui-addi-fusion,+fast-unaligned-access,+xtheadcondmov",
+  "linker": "rust-lld",
+  "linker-flavor": "ld.lld",
+  "llvm-abiname": "ilp32e",
+  "llvm-target": "riscv32",
+  "max-atomic-width": 32,
+  "panic-strategy": "abort",
+  "relocation-model": "pie",
+  "target-pointer-width": "32",
+  "singlethread": true,
+  "pre-link-args": {
+    "ld": [
+      "--emit-relocs",
+      "--unique",
+      "--relocatable"
+    ]
+  },
+  "env": "polkavm"
+}

--- a/guest-programs/rust-toolchain.toml
+++ b/guest-programs/rust-toolchain.toml
@@ -1,2 +1,3 @@
 [toolchain]
-channel = "riscv32em-nightly-2024-01-05-r0-x86_64-unknown-linux-gnu"
+channel = "nightly-2024-07-10"
+components = ["rust-src"]


### PR DESCRIPTION
Change from the Parity's rv32e fork to the official rustc toolchain.

Makes sure that also PolkaVM exports get relocation entry with the '--relocatable' parameters. Otherwise the linker will only add the relocs, whic are referenced by the code directly.

Flag DWARF processing under the feature flag 'dwarf' for the moment.

Link: https://github.com/paritytech/rustc-rv32e-toolchain/
Closes: #178