### PR TITLE
More 64-bit work

### DIFF
--- a/crates/polkavm-linker/src/program_from_elf.rs
+++ b/crates/polkavm-linker/src/program_from_elf.rs
@@ -3594,7 +3594,8 @@ impl OperationKind {
             Self::SetGreaterOrEqualUnsigned => i64::from((lhs as u64) >= (rhs as u64)),
             Self::SetGreaterOrEqualSigned => i64::from((lhs as i64) >= (rhs as i64)),
 
-            _ => todo!("64bit support"),
+            Self::Add64 => lhs.wrapping_add(rhs),
+            _ => todo!("unimplemented 64-bit operation: {self:?}"),
         }
     }
 

--- a/crates/polkavm-linker/src/program_from_elf.rs
+++ b/crates/polkavm-linker/src/program_from_elf.rs
@@ -7603,7 +7603,21 @@ where
                     src,
                     dst,
                     ..
-                } => {
+                } if !elf.is_64() => {
+                    let Some(dst) = cast_reg_non_zero(dst)? else {
+                        return Err(ProgramFromElfError::other(format!(
+                            "{lo_rel_name} with a zero destination register: 0x{lo_inst_raw:08x} in {section_name}[0x{relative_lo:08x}]"
+                        )));
+                    };
+
+                    (src, InstExt::Basic(BasicInst::LoadAddress { dst, target }))
+                }
+                Inst::RegImm {
+                    kind: RegImmKind::Add64,
+                    src,
+                    dst,
+                    ..
+                } if elf.is_64() => {
                     let Some(dst) = cast_reg_non_zero(dst)? else {
                         return Err(ProgramFromElfError::other(format!(
                             "{lo_rel_name} with a zero destination register: 0x{lo_inst_raw:08x} in {section_name}[0x{relative_lo:08x}]"

--- a/crates/polkavm/src/interpreter.rs
+++ b/crates/polkavm/src/interpreter.rs
@@ -2782,11 +2782,11 @@ impl<'a, const DEBUG: bool> InstructionVisitor for Compiler<'a, DEBUG> {
     }
 
     fn set_less_than_unsigned_64(&mut self, _d: RawReg, _s1: RawReg, _s2: RawReg) -> Self::ReturnTy {
-        self.trap()
+        todo!()
     }
 
     fn set_less_than_signed_64(&mut self, _d: RawReg, _s1: RawReg, _s2: RawReg) -> Self::ReturnTy {
-        self.trap()
+        todo!()
     }
 
     fn shift_logical_right(&mut self, d: RawReg, s1: RawReg, s2: RawReg) -> Self::ReturnTy {
@@ -2802,15 +2802,15 @@ impl<'a, const DEBUG: bool> InstructionVisitor for Compiler<'a, DEBUG> {
     }
 
     fn shift_logical_right_64(&mut self, _d: RawReg, _s1: RawReg, _s2: RawReg) -> Self::ReturnTy {
-        self.trap()
+        todo!()
     }
 
     fn shift_arithmetic_right_64(&mut self, _d: RawReg, _s1: RawReg, _s2: RawReg) -> Self::ReturnTy {
-        self.trap()
+        todo!()
     }
 
     fn shift_logical_left_64(&mut self, _d: RawReg, _s1: RawReg, _s2: RawReg) -> Self::ReturnTy {
-        self.trap()
+        todo!()
     }
 
     fn xor(&mut self, d: RawReg, s1: RawReg, s2: RawReg) -> Self::ReturnTy {
@@ -2826,15 +2826,15 @@ impl<'a, const DEBUG: bool> InstructionVisitor for Compiler<'a, DEBUG> {
     }
 
     fn xor_64(&mut self, _d: RawReg, _s1: RawReg, _s2: RawReg) -> Self::ReturnTy {
-        self.trap()
+        todo!()
     }
 
     fn and_64(&mut self, _d: RawReg, _s1: RawReg, _s2: RawReg) -> Self::ReturnTy {
-        self.trap()
+        todo!()
     }
 
     fn or_64(&mut self, _d: RawReg, _s1: RawReg, _s2: RawReg) -> Self::ReturnTy {
-        self.trap()
+        todo!()
     }
 
     fn add(&mut self, d: RawReg, s1: RawReg, s2: RawReg) -> Self::ReturnTy {
@@ -2842,7 +2842,7 @@ impl<'a, const DEBUG: bool> InstructionVisitor for Compiler<'a, DEBUG> {
     }
 
     fn add_64(&mut self, _d: RawReg, _s1: RawReg, _s2: RawReg) -> Self::ReturnTy {
-        self.trap()
+        todo!()
     }
 
     fn sub(&mut self, d: RawReg, s1: RawReg, s2: RawReg) -> Self::ReturnTy {
@@ -2850,7 +2850,7 @@ impl<'a, const DEBUG: bool> InstructionVisitor for Compiler<'a, DEBUG> {
     }
 
     fn sub_64(&mut self, _d: RawReg, _s1: RawReg, _s2: RawReg) -> Self::ReturnTy {
-        self.trap()
+        todo!()
     }
 
     fn negate_and_add_imm(&mut self, d: RawReg, s1: RawReg, s2: u32) -> Self::ReturnTy {
@@ -2862,7 +2862,7 @@ impl<'a, const DEBUG: bool> InstructionVisitor for Compiler<'a, DEBUG> {
     }
 
     fn mul_64(&mut self, _d: RawReg, _s1: RawReg, _s2: RawReg) -> Self::ReturnTy {
-        self.trap()
+        todo!()
     }
 
     fn mul_imm(&mut self, d: RawReg, s1: RawReg, s2: u32) -> Self::ReturnTy {
@@ -2870,27 +2870,27 @@ impl<'a, const DEBUG: bool> InstructionVisitor for Compiler<'a, DEBUG> {
     }
 
     fn mul_64_imm(&mut self, _d: RawReg, _s1: RawReg, _s2: u32) -> Self::ReturnTy {
-        self.trap()
+        todo!()
     }
 
     fn mul_upper_signed_signed_imm_64(&mut self, _: RawReg, _: RawReg, _: u32) -> <Self as InstructionVisitor>::ReturnTy {
-        self.trap()
+        todo!()
     }
 
     fn mul_upper_unsigned_unsigned_imm_64(&mut self, _: RawReg, _: RawReg, _: u32) -> <Self as InstructionVisitor>::ReturnTy {
-        self.trap()
+        todo!()
     }
 
     fn mul_upper_signed_signed_64(&mut self, _: RawReg, _: RawReg, _: RawReg) -> <Self as InstructionVisitor>::ReturnTy {
-        self.trap()
+        todo!()
     }
 
     fn mul_upper_unsigned_unsigned_64(&mut self, _: RawReg, _: RawReg, _: RawReg) -> <Self as InstructionVisitor>::ReturnTy {
-        self.trap()
+        todo!()
     }
 
     fn mul_upper_signed_unsigned_64(&mut self, _: RawReg, _: RawReg, _: RawReg) -> <Self as InstructionVisitor>::ReturnTy {
-        self.trap()
+        todo!()
     }
 
     fn mul_upper_signed_signed(&mut self, d: RawReg, s1: RawReg, s2: RawReg) -> Self::ReturnTy {
@@ -2930,19 +2930,19 @@ impl<'a, const DEBUG: bool> InstructionVisitor for Compiler<'a, DEBUG> {
     }
 
     fn div_unsigned_64(&mut self, _d: RawReg, _s1: RawReg, _s2: RawReg) -> Self::ReturnTy {
-        self.trap()
+        todo!()
     }
 
     fn div_signed_64(&mut self, _d: RawReg, _s1: RawReg, _s2: RawReg) -> Self::ReturnTy {
-        self.trap()
+        todo!()
     }
 
     fn rem_unsigned_64(&mut self, _d: RawReg, _s1: RawReg, _s2: RawReg) -> Self::ReturnTy {
-        self.trap()
+        todo!()
     }
 
     fn rem_signed_64(&mut self, _d: RawReg, _s1: RawReg, _s2: RawReg) -> Self::ReturnTy {
-        self.trap()
+        todo!()
     }
 
     fn set_less_than_unsigned_imm(&mut self, d: RawReg, s1: RawReg, s2: u32) -> Self::ReturnTy {
@@ -2962,19 +2962,19 @@ impl<'a, const DEBUG: bool> InstructionVisitor for Compiler<'a, DEBUG> {
     }
 
     fn set_less_than_unsigned_64_imm(&mut self, _d: RawReg, _s1: RawReg, _s2: u32) -> Self::ReturnTy {
-        self.trap()
+        todo!()
     }
 
     fn set_greater_than_unsigned_64_imm(&mut self, _d: RawReg, _s1: RawReg, _s2: u32) -> Self::ReturnTy {
-        self.trap()
+        todo!()
     }
 
     fn set_less_than_signed_64_imm(&mut self, _d: RawReg, _s1: RawReg, _s2: u32) -> Self::ReturnTy {
-        self.trap()
+        todo!()
     }
 
     fn set_greater_than_signed_64_imm(&mut self, _d: RawReg, _s1: RawReg, _s2: u32) -> Self::ReturnTy {
-        self.trap()
+        todo!()
     }
 
     fn shift_logical_right_imm(&mut self, d: RawReg, s1: RawReg, s2: u32) -> Self::ReturnTy {
@@ -3002,27 +3002,27 @@ impl<'a, const DEBUG: bool> InstructionVisitor for Compiler<'a, DEBUG> {
     }
 
     fn shift_logical_right_64_imm(&mut self, _d: RawReg, _s1: RawReg, _s2: u32) -> Self::ReturnTy {
-        self.trap()
+        todo!()
     }
 
     fn shift_logical_right_64_imm_alt(&mut self, _d: RawReg, _s2: RawReg, _s1: u32) -> Self::ReturnTy {
-        self.trap()
+        todo!()
     }
 
     fn shift_arithmetic_right_64_imm(&mut self, _d: RawReg, _s1: RawReg, _s2: u32) -> Self::ReturnTy {
-        self.trap()
+        todo!()
     }
 
     fn shift_arithmetic_right_64_imm_alt(&mut self, _d: RawReg, _s2: RawReg, _s1: u32) -> Self::ReturnTy {
-        self.trap()
+        todo!()
     }
 
     fn shift_logical_left_64_imm(&mut self, _d: RawReg, _s1: RawReg, _s2: u32) -> Self::ReturnTy {
-        self.trap()
+        todo!()
     }
 
     fn shift_logical_left_64_imm_alt(&mut self, _d: RawReg, _s2: RawReg, _s1: u32) -> Self::ReturnTy {
-        self.trap()
+        todo!()
     }
 
     fn or_imm(&mut self, d: RawReg, s1: RawReg, s2: u32) -> Self::ReturnTy {
@@ -3038,15 +3038,15 @@ impl<'a, const DEBUG: bool> InstructionVisitor for Compiler<'a, DEBUG> {
     }
 
     fn or_64_imm(&mut self, _d: RawReg, _s1: RawReg, _s2: u32) -> Self::ReturnTy {
-        self.trap()
+        todo!()
     }
 
     fn and_64_imm(&mut self, _d: RawReg, _s1: RawReg, _s2: u32) -> Self::ReturnTy {
-        self.trap()
+        todo!()
     }
 
     fn xor_64_imm(&mut self, _d: RawReg, _s1: RawReg, _s2: u32) -> Self::ReturnTy {
-        self.trap()
+        todo!()
     }
 
     fn load_imm(&mut self, dst: RawReg, imm: u32) -> Self::ReturnTy {
@@ -3074,7 +3074,7 @@ impl<'a, const DEBUG: bool> InstructionVisitor for Compiler<'a, DEBUG> {
     }
 
     fn add_64_imm(&mut self, _d: RawReg, _s1: RawReg, _s2: u32) -> Self::ReturnTy {
-        self.trap()
+        todo!()
     }
 
     fn add_imm(&mut self, d: RawReg, s1: RawReg, s2: u32) -> Self::ReturnTy {
@@ -3106,7 +3106,7 @@ impl<'a, const DEBUG: bool> InstructionVisitor for Compiler<'a, DEBUG> {
     }
 
     fn store_imm_u64(&mut self, _offset: u32, _value: u32) -> Self::ReturnTy {
-        self.trap()
+        todo!()
     }
 
     fn store_imm_indirect_u8(&mut self, base: RawReg, offset: u32, value: u32) -> Self::ReturnTy {
@@ -3134,7 +3134,7 @@ impl<'a, const DEBUG: bool> InstructionVisitor for Compiler<'a, DEBUG> {
     }
 
     fn store_imm_indirect_u64(&mut self, _base: RawReg, _offset: u32, _value: u32) -> Self::ReturnTy {
-        self.trap()
+        todo!()
     }
 
     fn store_indirect_u8(&mut self, src: RawReg, base: RawReg, offset: u32) -> Self::ReturnTy {
@@ -3162,7 +3162,7 @@ impl<'a, const DEBUG: bool> InstructionVisitor for Compiler<'a, DEBUG> {
     }
 
     fn store_indirect_u64(&mut self, _src: RawReg, _base: RawReg, _offset: u32) -> Self::ReturnTy {
-        self.trap()
+        todo!()
     }
 
     fn store_u8(&mut self, src: RawReg, offset: u32) -> Self::ReturnTy {
@@ -3190,7 +3190,7 @@ impl<'a, const DEBUG: bool> InstructionVisitor for Compiler<'a, DEBUG> {
     }
 
     fn store_u64(&mut self, _src: RawReg, _offset: u32) -> Self::ReturnTy {
-        self.trap()
+        todo!()
     }
 
     fn load_u8(&mut self, dst: RawReg, offset: u32) -> Self::ReturnTy {
@@ -3234,11 +3234,11 @@ impl<'a, const DEBUG: bool> InstructionVisitor for Compiler<'a, DEBUG> {
     }
 
     fn load_i32(&mut self, _dst: RawReg, _offset: u32) -> Self::ReturnTy {
-        self.trap()
+        todo!()
     }
 
     fn load_u64(&mut self, _dst: RawReg, _offset: u32) -> Self::ReturnTy {
-        self.trap()
+        todo!()
     }
 
     fn load_indirect_u8(&mut self, dst: RawReg, base: RawReg, offset: u32) -> Self::ReturnTy {
@@ -3282,11 +3282,11 @@ impl<'a, const DEBUG: bool> InstructionVisitor for Compiler<'a, DEBUG> {
     }
 
     fn load_indirect_i32(&mut self, _dst: RawReg, _base: RawReg, _offset: u32) -> Self::ReturnTy {
-        self.trap()
+        todo!()
     }
 
     fn load_indirect_u64(&mut self, _dst: RawReg, _base: RawReg, _offset: u32) -> Self::ReturnTy {
-        self.trap()
+        todo!()
     }
 
     fn branch_less_unsigned(&mut self, s1: RawReg, s2: RawReg, i: u32) -> Self::ReturnTy {

--- a/guest-programs/test-blob/src/main.rs
+++ b/guest-programs/test-blob/src/main.rs
@@ -56,7 +56,7 @@ extern "C" fn read_u32(address: u32) -> u32 {
 }
 
 #[polkavm_derive::polkavm_export]
-extern "C" fn atomic_fetch_add(value: u32) -> u32 {
+extern "C" fn atomic_fetch_add(value: usize) -> usize {
     unsafe {
         let output;
         core::arch::asm!(
@@ -69,7 +69,7 @@ extern "C" fn atomic_fetch_add(value: u32) -> u32 {
 }
 
 #[polkavm_derive::polkavm_export]
-extern "C" fn atomic_fetch_swap(value: u32) -> u32 {
+extern "C" fn atomic_fetch_swap(value: usize) -> usize {
     unsafe {
         let output;
         core::arch::asm!(
@@ -82,7 +82,7 @@ extern "C" fn atomic_fetch_swap(value: u32) -> u32 {
 }
 
 #[polkavm_derive::polkavm_export]
-extern "C" fn atomic_fetch_max_signed(value: i32) -> i32 {
+extern "C" fn atomic_fetch_max_signed(value: isize) -> isize {
     unsafe {
         let output;
         core::arch::asm!(
@@ -95,7 +95,7 @@ extern "C" fn atomic_fetch_max_signed(value: i32) -> i32 {
 }
 
 #[polkavm_derive::polkavm_export]
-extern "C" fn atomic_fetch_min_signed(value: i32) -> i32 {
+extern "C" fn atomic_fetch_min_signed(value: isize) -> isize {
     unsafe {
         let output;
         core::arch::asm!(
@@ -108,7 +108,7 @@ extern "C" fn atomic_fetch_min_signed(value: i32) -> i32 {
 }
 
 #[polkavm_derive::polkavm_export]
-extern "C" fn atomic_fetch_max_unsigned(value: u32) -> u32 {
+extern "C" fn atomic_fetch_max_unsigned(value: usize) -> usize {
     unsafe {
         let output;
         core::arch::asm!(
@@ -121,7 +121,7 @@ extern "C" fn atomic_fetch_max_unsigned(value: u32) -> u32 {
 }
 
 #[polkavm_derive::polkavm_export]
-extern "C" fn atomic_fetch_min_unsigned(value: u32) -> u32 {
+extern "C" fn atomic_fetch_min_unsigned(value: usize) -> usize {
     unsafe {
         let output;
         core::arch::asm!(
@@ -177,6 +177,7 @@ extern "C" fn test_multiply_by_6(value: u32) -> u32 {
 #[polkavm_derive::polkavm_define_abi(allow_extra_input_registers)]
 mod test_abi {}
 
+#[cfg(target_pointer_width = "32")]
 impl test_abi::FromHost for f32 {
     type Regs = (u32,);
     fn from_host((a0,): Self::Regs) -> Self {
@@ -184,11 +185,29 @@ impl test_abi::FromHost for f32 {
     }
 }
 
+#[cfg(target_pointer_width = "32")]
 impl test_abi::IntoHost for f32 {
     type Regs = (u32,);
     type Destructor = ();
     fn into_host(value: f32) -> (Self::Regs, Self::Destructor) {
         ((value.to_bits(),), ())
+    }
+}
+
+#[cfg(target_pointer_width = "64")]
+impl test_abi::FromHost for f32 {
+    type Regs = (u64,);
+    fn from_host((a0,): Self::Regs) -> Self {
+        f32::from_bits(a0 as u32)
+    }
+}
+
+#[cfg(target_pointer_width = "64")]
+impl test_abi::IntoHost for f32 {
+    type Regs = (u64,);
+    type Destructor = ();
+    fn into_host(value: f32) -> (Self::Regs, Self::Destructor) {
+        ((u64::from(value.to_bits()),), ())
     }
 }
 


### PR DESCRIPTION
The pinky benchmark should now compile in 64-bits (with the C extension and optimizations disabled).