### PR TITLE
pin the CI runner to ubuntu-22.04

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -11,7 +11,7 @@ env:
 
 jobs:
   build-and-test-linux:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
     - uses: actions/checkout@v4
     - name: Enable unprivileged userfaultfd
@@ -46,7 +46,7 @@ jobs:
       shell: bash
       run: ./ci/jobs/build-and-test.sh
   kani:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
     - uses: actions/checkout@v4
     - name: Install kani
@@ -56,7 +56,7 @@ jobs:
     - name: Run kani
       run: ./ci/jobs/kani.sh
   clippy:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
     - uses: actions/checkout@v4
     - name: Install clippy (base toolchain)
@@ -66,7 +66,7 @@ jobs:
     - name: Run clippy
       run: ./ci/jobs/clippy.sh
   rustfmt:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
     - uses: actions/checkout@v4
     - name: Install rustfmt (base toolchain)
@@ -76,7 +76,7 @@ jobs:
     - name: Run rustfmt
       run: ./ci/jobs/rustfmt.sh
   pallet-revive-tests:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
     - uses: actions/checkout@v4
     - name: Enable unprivileged userfaultfd
@@ -88,7 +88,7 @@ jobs:
     - name: Build and test
       run: ./ci/jobs/build-and-test-pallet-revive.sh
   fuzz:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
     - uses: actions/checkout@v4
     - name: Install cargo fuzz


### PR DESCRIPTION
Latest CI breakdown likely related to https://github.com/actions/runner-images/issues/10636