### PR TITLE
Handle Rust >= 1.91 change of `target-pointer-width` JSON type

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,7 +26,7 @@ version = "0.29.0"
 authors = ["Jan Bujak <jan@parity.io>", "Parity Technologies <admin@parity.io>"]
 license = "MIT/Apache-2.0"
 edition = "2021"
-rust-version = "1.86.0"
+rust-version = "1.91.0"
 repository = "https://github.com/koute/polkavm"
 
 [workspace.dependencies]

--- a/ci/jobs/build-and-test-pallet-revive.sh
+++ b/ci/jobs/build-and-test-pallet-revive.sh
@@ -3,7 +3,7 @@
 set -euo pipefail
 cd -- "$(dirname -- "${BASH_SOURCE[0]}")"
 
-rustup toolchain install --component=rust-src 1.88.0
+rustup toolchain install --component=rust-src 1.91.0
 
 POLKAVM_CRATES_ROOT="$(pwd)/proxy-crates"
 
@@ -21,9 +21,9 @@ git fetch --depth=1 origin $COMMIT
 git checkout $COMMIT
 
 echo '[toolchain]' > rust-toolchain.toml
-echo 'channel = "1.88.0"' >> rust-toolchain.toml
+echo 'channel = "1.91.0"' >> rust-toolchain.toml
 
-PALLET_REVIVE_FIXTURES_RUSTUP_TOOLCHAIN=1.88.0 \
+PALLET_REVIVE_FIXTURES_RUSTUP_TOOLCHAIN=1.91.0 \
 PALLET_REVIVE_FIXTURES_STRIP=0 \
 PALLET_REVIVE_FIXTURES_OPTIMIZE=1 \
 cargo test \

--- a/crates/polkavm-linker/riscv32emac-unknown-none-polkavm.json
+++ b/crates/polkavm-linker/riscv32emac-unknown-none-polkavm.json
@@ -13,7 +13,7 @@
   "max-atomic-width": 64,
   "panic-strategy": "abort",
   "relocation-model": "pie",
-  "target-pointer-width": "32",
+  "target-pointer-width": 32,
   "singlethread": true,
   "pre-link-args": {
     "ld": [

--- a/crates/polkavm-linker/riscv64emac-unknown-none-polkavm.json
+++ b/crates/polkavm-linker/riscv64emac-unknown-none-polkavm.json
@@ -13,7 +13,7 @@
   "max-atomic-width": 64,
   "panic-strategy": "abort",
   "relocation-model": "pie",
-  "target-pointer-width": "64",
+  "target-pointer-width": 64,
   "singlethread": true,
   "pre-link-args": {
     "ld": [

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,2 +1,2 @@
 [toolchain]
-channel = "1.86.0"
+channel = "1.91.0"

--- a/tools/benchtool/rust-toolchain.toml
+++ b/tools/benchtool/rust-toolchain.toml
@@ -1,2 +1,2 @@
 [toolchain]
-channel = "1.86.0"
+channel = "1.91.0"

--- a/tools/gastool/rust-toolchain.toml
+++ b/tools/gastool/rust-toolchain.toml
@@ -1,2 +1,2 @@
 [toolchain]
-channel = "1.86.0"
+channel = "1.91.0"


### PR DESCRIPTION
With the upcoming Rust 1.91, linking with `polkavm` will fail due to:

```
error: error loading target specification: target-pointer-width: invalid type: string "64", expected u16 at line 16 column 30
```

This can already be observed in Rust nightly.

The error occurs because of https://github.com/rust-lang/rust/pull/144443, which changes the `target-pointer-width` type.

This PR raises the MSRV throughout and accounts for this type change. I've raised the MSRV of `tools/{benchtool,gastool}` as well, as those use the `polkavm` linker too.

The CI will fail for now, but once Rust 1.91 is published ([October 30, 2025](https://releases.rs/docs/1.91.0/)) it will succeed. I'm already creating the PR now to surface that this is the cause of failure to link in nightly.