### PR TITLE
Fix memset's inconsitencies found by fuzzer

### DIFF
--- a/crates/polkavm/src/compiler/amd64.rs
+++ b/crates/polkavm/src/compiler/amd64.rs
@@ -1319,7 +1319,6 @@ where
         ));
 
         let count = conv_reg(Reg::A2.into());
-        self.asm.push(mov(RegSize::R32, count, count));
 
         match self.gas_metering {
             None => {

--- a/crates/polkavm/src/interpreter.rs
+++ b/crates/polkavm/src/interpreter.rs
@@ -3108,8 +3108,9 @@ define_interpreter! {
         let mut result = next_instruction;
 
         let value = visitor.get32::<DEBUG>(Reg::A1);
-        let mut dst = visitor.get32::<DEBUG>(Reg::A0);
-        let mut count = visitor.get64::<DEBUG>(Reg::A2);
+        let a0 = visitor.get64::<DEBUG>(Reg::A0);
+        let mut dst = cast(a0).truncate_to_u32();
+        let mut count = u64::from(visitor.get32::<DEBUG>(Reg::A2));
         while count > 0 {
             if gas_metering_enabled && visitor.gas == 0 {
                 result = not_enough_gas_impl::<DEBUG>(visitor, compiled_offset, program_counter, 0);
@@ -3129,7 +3130,7 @@ define_interpreter! {
             count -= 1;
         }
 
-        visitor.set64::<DEBUG>(Reg::A0, u64::from(dst));
+        visitor.set64::<DEBUG>(Reg::A0, a0.wrapping_add(u64::from(dst.wrapping_sub(cast(a0).truncate_to_u32()))));
         visitor.set64::<DEBUG>(Reg::A2, count);
 
         result

--- a/crates/polkavm/src/tests.rs
+++ b/crates/polkavm/src/tests.rs
@@ -4571,6 +4571,44 @@ fn memset_with_dynamic_paging(mut config: Config) {
     assert_eq!(instance.gas(), 95);
 }
 
+fn memset_preserves_a0_and_a2(config: Config) {
+    let _ = env_logger::try_init();
+
+    // Memset must not truncate A0 or A2. With count=0, memset is a no-op
+    // and both registers must pass through with their upper 32 bits intact.
+    let mut builder = ProgramBlobBuilder::new(InstructionSetKind::Latest64);
+    builder.add_export_by_basic_block(0, b"main");
+    builder.set_code(
+        &[
+            // A0 = 0xffffffffffff0000 * 0xffffffffffff0000 = 0x0000000100000000
+            asm::load_imm(Reg::A0, 0xffff0000),
+            asm::mul_64(Reg::A0, Reg::A0, Reg::A0),
+            // A2 = sign_extend(0xff08bdbd) = 0xffffffffff08bdbd
+            asm::load_imm(Reg::A2, 0xff08bdbd),
+            // Swap A2 into A3 so we can set count=0 while keeping the test value.
+            asm::move_reg(Reg::A3, Reg::A2),
+            asm::load_imm(Reg::A2, 0),
+            asm::memset(),
+            asm::ret(),
+        ],
+        &[],
+    );
+
+    let blob = ProgramBlob::parse(builder.into_vec().unwrap().into()).unwrap();
+    let engine = Engine::new(&config).unwrap();
+    let module = Module::from_blob(&engine, &ModuleConfig::new(), blob).unwrap();
+
+    let mut instance = module.instantiate().unwrap();
+    instance.set_reg(Reg::RA, crate::RETURN_TO_HOST);
+    instance.set_next_program_counter(ProgramCounter(0));
+    assert!(matches!(instance.run().unwrap(), InterruptKind::Finished));
+    assert_eq!(instance.reg(Reg::A0), 0x0000000100000000, "memset truncated A0");
+    // A2 was set to 0 (count), so it should be 0 after memset.
+    assert_eq!(instance.reg(Reg::A2), 0);
+    // A3 was never touched by memset, just a sanity check.
+    assert_eq!(instance.reg(Reg::A3), 0xffffffffff08bdbd);
+}
+
 fn count_leading_zero_bits_32_with_zero_input(config: Config) {
     let _ = env_logger::try_init();
 
@@ -5245,6 +5283,7 @@ run_tests! {
     count_trailing_zero_bits_32_with_zero_input
     count_trailing_zero_bits_64_with_zero_input
     count_trailing_zero_bits_64_with_ffff0000
+    memset_preserves_a0_and_a2
 }
 
 run_test_blob_tests! {

--- a/crates/polkavm/src/tests.rs
+++ b/crates/polkavm/src/tests.rs
@@ -4578,34 +4578,22 @@ fn memset_preserves_a0_and_a2(config: Config) {
     // and both registers must pass through with their upper 32 bits intact.
     let mut builder = ProgramBlobBuilder::new(InstructionSetKind::Latest64);
     builder.add_export_by_basic_block(0, b"main");
-    builder.set_code(
-        &[
-            // A0 = 0xffffffffffff0000 * 0xffffffffffff0000 = 0x0000000100000000
-            asm::load_imm(Reg::A0, 0xffff0000),
-            asm::mul_64(Reg::A0, Reg::A0, Reg::A0),
-            // A2 = sign_extend(0xff08bdbd) = 0xffffffffff08bdbd
-            asm::load_imm(Reg::A2, 0xff08bdbd),
-            // Swap A2 into A3 so we can set count=0 while keeping the test value.
-            asm::move_reg(Reg::A3, Reg::A2),
-            asm::load_imm(Reg::A2, 0),
-            asm::memset(),
-            asm::ret(),
-        ],
-        &[],
-    );
+    builder.set_code(&[asm::memset(), asm::ret()], &[]);
 
     let blob = ProgramBlob::parse(builder.into_vec().unwrap().into()).unwrap();
     let engine = Engine::new(&config).unwrap();
     let module = Module::from_blob(&engine, &ModuleConfig::new(), blob).unwrap();
 
     let mut instance = module.instantiate().unwrap();
+    instance.set_reg(Reg::A0, 0x0000000100000000);
+    instance.set_reg(Reg::A1, 0);
+    instance.set_reg(Reg::A2, 0);
+    instance.set_reg(Reg::A3, 0xffffffffff08bdbd);
     instance.set_reg(Reg::RA, crate::RETURN_TO_HOST);
     instance.set_next_program_counter(ProgramCounter(0));
     assert!(matches!(instance.run().unwrap(), InterruptKind::Finished));
     assert_eq!(instance.reg(Reg::A0), 0x0000000100000000, "memset truncated A0");
-    // A2 was set to 0 (count), so it should be 0 after memset.
     assert_eq!(instance.reg(Reg::A2), 0);
-    // A3 was never touched by memset, just a sanity check.
     assert_eq!(instance.reg(Reg::A3), 0xffffffffff08bdbd);
 }
 

--- a/fuzz/fuzz_targets/fuzz_polkavm.rs
+++ b/fuzz/fuzz_targets/fuzz_polkavm.rs
@@ -299,13 +299,24 @@ fn transform_code(data: Vec<OperationKind>) -> Vec<Instruction> {
     for op in data {
         let op = match op {
             OperationKind::Argless { kind } => {
-                codegen! {
-                    args = (),
-                    kind = kind,
-                    {
-                        ArglessKind::Trap => trap,
-                        ArglessKind::Fallthrough => fallthrough,
-                        ArglessKind::Memset => memset,
+                match kind {
+                    ArglessKind::Memset => {
+                        // Truncate A0 and A2 to 32-bit before memset so the
+                        // fuzzer exercises memset with 32-bit-range addresses and counts.
+                        buffer.push(asm::add_imm_32(Reg::A0, Reg::A0, 0));
+                        buffer.push(asm::add_imm_32(Reg::A2, Reg::A2, 0));
+                        asm::memset()
+                    }
+                    _ => {
+                        codegen! {
+                            args = (),
+                            kind = kind,
+                            {
+                                ArglessKind::Trap => trap,
+                                ArglessKind::Fallthrough => fallthrough,
+                                ArglessKind::Memset => memset,
+                            }
+                        }
                     }
                 }
             }

--- a/fuzz/fuzz_targets/fuzz_polkavm.rs
+++ b/fuzz/fuzz_targets/fuzz_polkavm.rs
@@ -299,24 +299,13 @@ fn transform_code(data: Vec<OperationKind>) -> Vec<Instruction> {
     for op in data {
         let op = match op {
             OperationKind::Argless { kind } => {
-                match kind {
-                    ArglessKind::Memset => {
-                        // Truncate A0 and A2 to 32-bit before memset so the
-                        // fuzzer exercises memset with 32-bit-range addresses and counts.
-                        buffer.push(asm::add_imm_32(Reg::A0, Reg::A0, 0));
-                        buffer.push(asm::add_imm_32(Reg::A2, Reg::A2, 0));
-                        asm::memset()
-                    }
-                    _ => {
-                        codegen! {
-                            args = (),
-                            kind = kind,
-                            {
-                                ArglessKind::Trap => trap,
-                                ArglessKind::Fallthrough => fallthrough,
-                                ArglessKind::Memset => memset,
-                            }
-                        }
+                codegen! {
+                    args = (),
+                    kind = kind,
+                    {
+                        ArglessKind::Trap => trap,
+                        ArglessKind::Fallthrough => fallthrough,
+                        ArglessKind::Memset => memset,
                     }
                 }
             }


### PR DESCRIPTION
    - The fuzzer identified divergency in interpreter and recompiler when
        following code was executed
    
        ```
        // All registers are zeroed
    
        1 fallthrough
        2 shift_logical_left_imm_alt_64(A0, A0, 0x8F8F030F)
        3 sub_32(SP, T0, A2)
        4 branch_less_signed(A0, A0, target=0)
        5 memset()
        6 branch_less_signed(S1, A0, target=0)
        7 store_imm_indirect_u8(RA, 0, 0)
        ```
    
        when `memset` is executed, A0 is `0xFFFFFFFF8F8F030F`, which interpreter
        truncated to `0x000000008F8F030F`, while recompiler preserved A.
    
        Later that resulted that 6 branch instruction is taken by interpreter
        and it runs out of gas, while recompiler tries to executed store which
        resulted to trap.
    
        To fix it, bookkeep `dst` register before 32-bit truncation, restore the
        register to original ptr + number of executed iterations. This prevents `A0`
        clobbering that may be used later
    
    - the other problem was due inconsistent behavior on `count`:
      recompiler truncates that register to 32-bit value, while interpreter
      keeps it as 64-bit value.
    
      To fix it, keep `count` register as 64-bit integer in recompiler