### PR TITLE
linker: fix orn/xnor/min/max with a zero register on RV64

### DIFF
--- a/crates/polkavm-linker/src/program_from_elf.rs
+++ b/crates/polkavm-linker/src/program_from_elf.rs
@@ -1808,17 +1808,24 @@ fn emit_minmax(
     }));
 }
 
+/// Rewrites `orn`/`xnor`/`min`/`max` with a zero source register into simpler
+/// instructions. These are XLEN-wide ops with no 32-bit variant, so on RV64
+/// the rewrite must use the 64-bit forms: a 32-bit op would sign-extend the low
+/// 32 bits and corrupt the upper half when the operand is not a sign-extended
+/// 32-bit value.
 fn resolve_simple_zero_register_usage(
     kind: crate::riscv::RegRegKind,
     dst: Reg,
     src1: RReg,
     src2: RReg,
+    rv64: bool,
     mut emit: impl FnMut(InstExt<SectionTarget, SectionTarget>),
 ) -> bool {
     use crate::riscv::RegRegKind as K;
+    let xor = if rv64 { AnyAnyKind::Xor64 } else { AnyAnyKind::Xor32 };
     if kind == K::OrInverted && src1 == RReg::Zero && src2 != RReg::Zero {
         emit(InstExt::Basic(BasicInst::AnyAny {
-            kind: AnyAnyKind::Xor32,
+            kind: xor,
             dst,
             src1: RegImm::Imm(!0),
             src2: cast_reg_any(src2).unwrap(),
@@ -1828,7 +1835,7 @@ fn resolve_simple_zero_register_usage(
 
     if kind == K::Xnor && src1 == RReg::Zero && src2 != RReg::Zero {
         emit(InstExt::Basic(BasicInst::AnyAny {
-            kind: AnyAnyKind::Xor32,
+            kind: xor,
             dst,
             src1: RegImm::Imm(!0),
             src2: cast_reg_any(src2).unwrap(),
@@ -1838,7 +1845,7 @@ fn resolve_simple_zero_register_usage(
 
     if kind == K::Xnor && src1 != RReg::Zero && src2 == RReg::Zero {
         emit(InstExt::Basic(BasicInst::AnyAny {
-            kind: AnyAnyKind::Xor32,
+            kind: xor,
             dst,
             src1: cast_reg_any(src1).unwrap(),
             src2: RegImm::Imm(!0),
@@ -1855,9 +1862,14 @@ fn resolve_simple_zero_register_usage(
         let tmp = Reg::E2;
         let src1 = cast_reg_any(src1).unwrap();
         let src2 = cast_reg_any(src2).unwrap();
+        let less_than = if rv64 {
+            AnyAnyKind::SetLessThanSigned64
+        } else {
+            AnyAnyKind::SetLessThanSigned32
+        };
         let (kind, cmp_src1, cmp_src2) = match kind {
-            K::Minimum => (AnyAnyKind::SetLessThanSigned32, src1, src2),
-            K::Maximum => (AnyAnyKind::SetLessThanSigned32, src2, src1),
+            K::Minimum => (less_than, src1, src2),
+            K::Maximum => (less_than, src2, src1),
             _ => unreachable!(),
         };
 
@@ -2273,7 +2285,7 @@ fn convert_instruction(
                 };
             }
 
-            if resolve_simple_zero_register_usage(kind, dst, src1, src2, &mut emit) {
+            if resolve_simple_zero_register_usage(kind, dst, src1, src2, rv64, &mut emit) {
                 emit(InstExt::nop());
                 return Ok(());
             };

--- a/crates/polkavm-linker/src/program_from_elf.rs
+++ b/crates/polkavm-linker/src/program_from_elf.rs
@@ -1808,11 +1808,6 @@ fn emit_minmax(
     }));
 }
 
-/// Rewrites `orn`/`xnor`/`min`/`max` with a zero source register into simpler
-/// instructions. These are XLEN-wide ops with no 32-bit variant, so on RV64
-/// the rewrite must use the 64-bit forms: a 32-bit op would sign-extend the low
-/// 32 bits and corrupt the upper half when the operand is not a sign-extended
-/// 32-bit value.
 fn resolve_simple_zero_register_usage(
     kind: crate::riscv::RegRegKind,
     dst: Reg,

--- a/crates/polkavm/src/tests.rs
+++ b/crates/polkavm/src/tests.rs
@@ -3963,6 +3963,42 @@ fn test_blob_sub_i32_min_32(args: TestBlobArgs) {
     assert_eq!(i.call::<(u64,), u64>("sub_i32_min_32", (0,)).unwrap(), 0xffffffff80000000);
 }
 
+fn test_blob_orn_zero_const_64(args: TestBlobArgs) {
+    if !args.is_64_bit {
+        return;
+    }
+    let elf = args.get_test_program();
+    let mut i = TestInstance::new(&args.config, elf, args.optimize);
+    assert_eq!(i.call::<(), u64>("orn_zero_const_64", ()).unwrap(), 0x80000001);
+}
+
+fn test_blob_xnor_zero_const_64(args: TestBlobArgs) {
+    if !args.is_64_bit {
+        return;
+    }
+    let elf = args.get_test_program();
+    let mut i = TestInstance::new(&args.config, elf, args.optimize);
+    assert_eq!(i.call::<(), u64>("xnor_zero_const_64", ()).unwrap(), 0x80000001);
+}
+
+fn test_blob_min_zero_const_64(args: TestBlobArgs) {
+    if !args.is_64_bit {
+        return;
+    }
+    let elf = args.get_test_program();
+    let mut i = TestInstance::new(&args.config, elf, args.optimize);
+    assert_eq!(i.call::<(), u64>("min_zero_const_64", ()).unwrap(), 0xffffffff7ffffffe);
+}
+
+fn test_blob_max_zero_const_64(args: TestBlobArgs) {
+    if !args.is_64_bit {
+        return;
+    }
+    let elf = args.get_test_program();
+    let mut i = TestInstance::new(&args.config, elf, args.optimize);
+    assert_eq!(i.call::<(), u64>("max_zero_const_64", ()).unwrap(), 0);
+}
+
 fn test_asm_reloc_add_sub(config: Config, optimize: bool) {
     const BLOB_64: &[u8] = include_bytes!("../../../guest-programs/asm-tests/output/reloc_add_sub_64.elf");
 
@@ -5389,6 +5425,10 @@ run_test_blob_tests! {
     test_blob_get_self_address_naked
     test_blob_sub_i32_min_64
     test_blob_sub_i32_min_32
+    test_blob_orn_zero_const_64
+    test_blob_xnor_zero_const_64
+    test_blob_min_zero_const_64
+    test_blob_max_zero_const_64
 }
 
 run_asm_tests! {

--- a/guest-programs/test-blob/src/common.rs
+++ b/guest-programs/test-blob/src/common.rs
@@ -516,3 +516,63 @@ extern "C" fn sub_i32_min_32(a0: u64) -> u64 {
         output
     }
 }
+
+#[cfg(target_pointer_width = "64")]
+#[polkavm_derive::polkavm_export]
+extern "C" fn orn_zero_const_64() -> u64 {
+    unsafe {
+        let output;
+        core::arch::asm!(
+            "lui a0, 0x80000",
+            "addi a0, a0, -2",
+            "orn a0, zero, a0",
+            out("a0") output,
+        );
+        output
+    }
+}
+
+#[cfg(target_pointer_width = "64")]
+#[polkavm_derive::polkavm_export]
+extern "C" fn xnor_zero_const_64() -> u64 {
+    unsafe {
+        let output;
+        core::arch::asm!(
+            "lui a0, 0x80000",
+            "addi a0, a0, -2",
+            "xnor a0, a0, zero",
+            out("a0") output,
+        );
+        output
+    }
+}
+
+#[cfg(target_pointer_width = "64")]
+#[polkavm_derive::polkavm_export]
+extern "C" fn min_zero_const_64() -> u64 {
+    unsafe {
+        let output;
+        core::arch::asm!(
+            "lui a0, 0x80000",
+            "addi a0, a0, -2",
+            "min a0, a0, zero",
+            out("a0") output,
+        );
+        output
+    }
+}
+
+#[cfg(target_pointer_width = "64")]
+#[polkavm_derive::polkavm_export]
+extern "C" fn max_zero_const_64() -> u64 {
+    unsafe {
+        let output;
+        core::arch::asm!(
+            "lui a0, 0x80000",
+            "addi a0, a0, -2",
+            "max a0, a0, zero",
+            out("a0") output,
+        );
+        output
+    }
+}


### PR DESCRIPTION
`resolve_simple_zero_register_usage` rewrote `orn`/`xnor`/`min`/`max` with a zero register to 32-bit ops (`Xor32`/`SetLessThanSigned32`) unconditionally. These instructions are XLEN-wide, so on RV64 the rewrite must use the 64-bit forms.

The 32- and 64-bit ops share a runtime instruction but differ in the linker's constant folder: the 32-bit path truncates to i32 and sign-extends, which panics with `operand overflow: TryFromIntError` when the folded operand is outside i32 (e.g. `~0x80000000`) and corrupts bits 32..64 otherwise.

[Found in resolc at `-O3`](https://github.com/paritytech/revive/issues/551), the reproducer works correctly (differential against EVM) with this fix.