### PR TITLE
 Add a metadata section

### DIFF
--- a/crates/polkavm-common/src/program.rs
+++ b/crates/polkavm-common/src/program.rs
@@ -4111,6 +4111,8 @@ pub struct ProgramBlob {
     debug_strings: ArcBytes,
     debug_line_program_ranges: ArcBytes,
     debug_line_programs: ArcBytes,
+
+    metadata_hash: ArcBytes,
 }
 
 struct Reader<'a, T>
@@ -5118,6 +5120,8 @@ pub struct ProgramParts {
     pub debug_strings: ArcBytes,
     pub debug_line_program_ranges: ArcBytes,
     pub debug_line_programs: ArcBytes,
+
+    pub metadata_hash: ArcBytes,
 }
 
 impl ProgramParts {
@@ -5138,6 +5142,8 @@ impl ProgramParts {
             debug_strings: Default::default(),
             debug_line_program_ranges: Default::default(),
             debug_line_programs: Default::default(),
+
+            metadata_hash: Default::default(),
         }
     }
 
@@ -5212,6 +5218,7 @@ impl ProgramParts {
         parts.debug_strings = reader.read_section_as_bytes(&mut section, SECTION_OPT_DEBUG_STRINGS)?;
         parts.debug_line_programs = reader.read_section_as_bytes(&mut section, SECTION_OPT_DEBUG_LINE_PROGRAMS)?;
         parts.debug_line_program_ranges = reader.read_section_as_bytes(&mut section, SECTION_OPT_DEBUG_LINE_PROGRAM_RANGES)?;
+        parts.metadata_hash = reader.read_section_as_bytes(&mut section, SECTION_OPT_METADATA_HASH)?;
 
         while (section & 0b10000000) != 0 {
             // We don't know this section, but it's optional, so just skip it.
@@ -5276,6 +5283,8 @@ impl ProgramBlob {
             debug_strings: parts.debug_strings,
             debug_line_program_ranges: parts.debug_line_program_ranges,
             debug_line_programs: parts.debug_line_programs,
+
+            metadata_hash: parts.metadata_hash,
         };
 
         if blob.ro_data.len() > blob.ro_data_size as usize {
@@ -5381,6 +5390,11 @@ impl ProgramBlob {
         }
     }
 
+    /// Returns the metadata hash embedded in the blob, or an empty slice if none is present.
+    pub fn metadata_hash(&self) -> &[u8] {
+        &self.metadata_hash
+    }
+
     /// Calculates an unique hash of the program blob.
     pub fn unique_hash(&self, include_debug: bool) -> crate::hasher::Hash {
         let ProgramBlob {
@@ -5402,6 +5416,7 @@ impl ProgramBlob {
             debug_strings,
             debug_line_program_ranges,
             debug_line_programs,
+            metadata_hash: _,
         } = self;
 
         let mut hasher = crate::hasher::Hasher::new();
@@ -5813,6 +5828,7 @@ impl ProgramBlob {
             debug_strings,
             debug_line_program_ranges,
             debug_line_programs,
+            metadata_hash,
         } = self;
 
         let mut ranges = [
@@ -5827,6 +5843,7 @@ impl ProgramBlob {
             debug_strings.parent_address_range(),
             debug_line_program_ranges.parent_address_range(),
             debug_line_programs.parent_address_range(),
+            metadata_hash.parent_address_range(),
         ];
 
         ranges.sort_unstable_by_key(|r| r.start);
@@ -5938,6 +5955,7 @@ fn test_calculate_blob_length() {
         exports: Default::default(),
         debug_line_program_ranges: Default::default(),
         debug_line_programs: Default::default(),
+        metadata_hash: Default::default(),
     };
 
     let blob = ProgramBlob::from_parts(parts).unwrap();
@@ -6455,6 +6473,7 @@ pub const SECTION_CODE_AND_JUMP_TABLE: u8 = 6;
 pub const SECTION_OPT_DEBUG_STRINGS: u8 = 128;
 pub const SECTION_OPT_DEBUG_LINE_PROGRAMS: u8 = 129;
 pub const SECTION_OPT_DEBUG_LINE_PROGRAM_RANGES: u8 = 130;
+pub const SECTION_OPT_METADATA_HASH: u8 = 131;
 pub const SECTION_END_OF_FILE: u8 = 0;
 
 pub const VERSION_DEBUG_LINE_PROGRAM_V1: u8 = 1;

--- a/crates/polkavm-common/src/writer.rs
+++ b/crates/polkavm-common/src/writer.rs
@@ -605,3 +605,31 @@ impl<'a> Writer<'a> {
         self.buffer.is_empty()
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::ProgramBlobBuilder;
+    use crate::program::{Instruction, InstructionSetKind, ProgramBlob, SECTION_OPT_METADATA_HASH};
+
+    fn build_minimal(metadata_hash: Option<&[u8]>) -> ProgramBlob {
+        let mut builder = ProgramBlobBuilder::new(InstructionSetKind::ReviveV1);
+        builder.set_code(&[Instruction::trap], &[]);
+        if let Some(metadata_hash) = metadata_hash {
+            builder.add_custom_section(SECTION_OPT_METADATA_HASH, metadata_hash.to_vec());
+        }
+        ProgramBlob::parse(builder.to_vec().unwrap().into()).unwrap()
+    }
+
+    #[test]
+    fn metadata_hash_section_round_trips() {
+        let metadata_hash = [0xab_u8; 32];
+        let blob = build_minimal(Some(&metadata_hash));
+        assert_eq!(blob.metadata_hash(), metadata_hash);
+    }
+
+    #[test]
+    fn metadata_hash_is_empty_when_absent() {
+        let blob = build_minimal(None);
+        assert!(blob.metadata_hash().is_empty());
+    }
+}

--- a/crates/polkavm-linker/src/program_from_elf.rs
+++ b/crates/polkavm-linker/src/program_from_elf.rs
@@ -10006,6 +10006,7 @@ pub struct Config {
     dispatch_table: Vec<Vec<u8>>,
     min_stack_size: u32,
     gas_cost_model_aware_optimizations: bool,
+    metadata_hash: Option<Vec<u8>>,
 }
 
 impl Default for Config {
@@ -10018,6 +10019,7 @@ impl Default for Config {
             dispatch_table: Vec::new(),
             min_stack_size: VM_MIN_PAGE_SIZE * 2,
             gas_cost_model_aware_optimizations: true,
+            metadata_hash: None,
         }
     }
 }
@@ -10060,6 +10062,11 @@ impl Config {
 
     pub fn set_enable_gas_cost_model_aware_optimizations(&mut self, value: bool) -> &mut Self {
         self.gas_cost_model_aware_optimizations = value;
+        self
+    }
+
+    pub fn set_metadata_hash(&mut self, value: Option<Vec<u8>>) -> &mut Self {
+        self.metadata_hash = value;
         self
     }
 }
@@ -11078,6 +11085,10 @@ fn program_from_elf_internal(config: Config, isa: TargetInstructionSet, mut elf:
         assert_eq!(offsets.len(), locations_for_instruction.len());
 
         emit_debug_info(&mut builder, &locations_for_instruction, &offsets);
+    }
+
+    if let Some(metadata_hash) = config.metadata_hash.clone() {
+        builder.add_custom_section(program::SECTION_OPT_METADATA_HASH, metadata_hash);
     }
 
     let raw_blob = builder.to_vec().map_err(ProgramFromElfError::other)?;

--- a/crates/polkavm-linker/src/tests.rs
+++ b/crates/polkavm-linker/src/tests.rs
@@ -181,3 +181,32 @@ fn trap_is_not_injected_at_the_end() {
         .replace("        ", "")
     );
 }
+
+#[test]
+fn metadata_hash_is_embedded_in_blob() {
+    let _ = env_logger::try_init();
+
+    let bytes = create_elf(&[0x00b50533, 0x00008067]);
+    let metadata_hash = [0x42u8; 32];
+
+    let mut config = Config::default();
+    config.set_optimize(false);
+    config.set_metadata_hash(Some(metadata_hash.to_vec()));
+    let program = program_from_elf(config, TargetInstructionSet::Latest, &bytes).unwrap();
+
+    let blob = polkavm_common::program::ProgramBlob::parse(program.as_slice().into()).unwrap();
+    assert_eq!(blob.metadata_hash(), metadata_hash);
+}
+
+#[test]
+fn metadata_hash_is_absent_by_default() {
+    let _ = env_logger::try_init();
+
+    let bytes = create_elf(&[0x00b50533, 0x00008067]);
+    let mut config = Config::default();
+    config.set_optimize(false);
+    let program = program_from_elf(config, TargetInstructionSet::Latest, &bytes).unwrap();
+
+    let blob = polkavm_common::program::ProgramBlob::parse(program.as_slice().into()).unwrap();
+    assert!(blob.metadata_hash().is_empty());
+}


### PR DESCRIPTION
Contract blobs benefit from having an embedded _metadata hash_. The idea is that the compiler hashes source input, settings and other relevant metadata using a cryptographically secure hash, creating a fingerprint committing to everything that influences the compilation output. Embedding the fingerprint inside the code blob puts it under consensus.

Third parties can then use this fingerprint to verify if a given source code was indeed compiled to a given on-chain contract blob. The problem is reproducibility: Given a code blob, it can be hard to reproduce the build to an exact match. The verifier needs to guess the exact source code and compilation metadata (like the compiler version and settings used). The metadata hash mechanism allows contract deployers to publish the pre-image of the fingerprint, for example into a decentralized key-value store, such that verifiers can look it up and actually reproduce the contract build.

This PR adds such a metadata section. `solc` supports this too, in a [more hacky way via CBOR](https://docs.soliditylang.org/en/latest/metadata.html). See also this [forum thread](https://forum.polkadot.network/t/revive-deterministic-verifiable-contracts/16042/7) for more information.