### PR TITLE
Clamp register nibbles 13-15 to A5 in the recompiler

### DIFF
--- a/crates/polkavm/src/compiler/amd64.rs
+++ b/crates/polkavm/src/compiler/amd64.rs
@@ -49,8 +49,27 @@ impl From<i32> for RegImm {
     }
 }
 
+/// PVM register operands are 4-bit fields; the spec clamps a nibble greater than the highest
+/// register index down to that register (see `RawReg::get`). This is that clamp target.
+const OUT_OF_BOUNDS_REG: Reg = {
+    let mut index = 1;
+    let mut max_reg = Reg::ALL[0];
+    while index < Reg::ALL.len() {
+        let reg = Reg::ALL[index];
+        if reg as usize > max_reg as usize {
+            max_reg = reg;
+        }
+        index += 1;
+    }
+    assert!(max_reg as usize == Reg::A5 as usize);
+    max_reg
+};
+
 static REG_MAP: [NativeReg; 16] = {
-    let mut output = [conv_reg_const(Reg::T2); 16];
+    // Register nibbles greater than the highest register index are clamped to `OUT_OF_BOUNDS_REG`
+    // (see `RawReg::get`), so map the unused indices there too.
+    // (See https://github.com/paritytech/polkavm/issues/391.)
+    let mut output = [conv_reg_const(OUT_OF_BOUNDS_REG); 16];
     let mut index = 0;
     while index < Reg::ALL.len() {
         assert!(Reg::ALL[index] as usize == index);
@@ -72,6 +91,13 @@ fn conv_reg(reg: RawReg) -> NativeReg {
 fn test_conv_reg() {
     for reg in Reg::ALL {
         assert_eq!(conv_reg(reg.into()), conv_reg_const(reg));
+    }
+
+    // Register nibbles greater than the highest register index are clamped to `OUT_OF_BOUNDS_REG`.
+    for nibble in 13..16 {
+        let reg = polkavm_common::program::read_args_regs2(u128::from(nibble)).0;
+        assert_eq!(reg.raw_unparsed(), nibble);
+        assert_eq!(conv_reg(reg), conv_reg_const(OUT_OF_BOUNDS_REG));
     }
 }
 

--- a/crates/polkavm/src/tests.rs
+++ b/crates/polkavm/src/tests.rs
@@ -5006,6 +5006,36 @@ fn jam_validate_invalid_skip(config: Config) {
     ));
 }
 
+fn jam_reg_nibble_clamped_to_a5(config: Config) {
+    let _ = env_logger::try_init();
+    let engine = Engine::new(&config).unwrap();
+
+    // Register nibbles greater than 12 are clamped to 12 (see `RawReg::get`), so a `load_imm`
+    // whose destination nibble is 13, 14 or 15 must still write to A5 and not to T2.
+    // (See https://github.com/paritytech/polkavm/issues/391.)
+    for nibble in 13..=15 {
+        let mut builder = ProgramBlobBuilder::new(InstructionSetKind::JamV1);
+        builder.add_export_by_basic_block(0, b"main");
+        builder.set_code(&[asm::load_imm(Reg::A5, 0x12345678), asm::ret()], &[]);
+        let mut blob = ProgramBlob::parse(builder.into_vec().unwrap().into()).unwrap();
+
+        // Rewrite `load_imm`'s destination register nibble from 12 to the out-of-bounds value.
+        let mut raw_code = blob.code().to_vec();
+        assert_eq!(raw_code[1], 12);
+        raw_code[1] = nibble;
+        blob.set_code(raw_code.into());
+        assert!(blob.validate_code_with_isa(polkavm_common::program::ISA_JamV1).is_ok());
+
+        let module = Module::from_blob(&engine, &ModuleConfig::new(), blob).unwrap();
+        let mut instance = module.instantiate().unwrap();
+        instance.set_reg(Reg::RA, crate::RETURN_TO_HOST);
+        instance.set_next_program_counter(ProgramCounter(0));
+        assert!(matches!(instance.run().unwrap(), InterruptKind::Finished));
+        assert_eq!(instance.reg(Reg::A5), 0x12345678);
+        assert_eq!(instance.reg(Reg::T2), 0);
+    }
+}
+
 fn test_basic_debug_info(raw_blob: &'static [u8]) {
     let _ = env_logger::try_init();
     let program = get_blob(raw_blob);
@@ -5419,6 +5449,7 @@ run_tests! {
     jam_validate_invalid_fallthrough
     jam_validate_invalid_branch
     jam_validate_invalid_skip
+    jam_reg_nibble_clamped_to_a5
 
     spawn_stress_test
     spawn_inner_vm


### PR DESCRIPTION
# Description

PVM register operands are 4-bit fields the spec clamps to register 12 (A5): the Graypaper decodes them as `min(12, nibble)` and the interpreter clamps in `RawReg::get`. The x86-64 recompiler's `conv_reg` indexes `REG_MAP` with the raw unclamped nibble, and `REG_MAP` left indices 13–15 at the placeholder `T2` — so a register nibble of 13/14/15 silently compiled to T2 instead of A5 in release builds (the `debug_assert_eq!` in `conv_reg` catches it in debug builds).

This fills `REG_MAP`'s unused indices with `A5` so the recompiler matches `RawReg::get`, extends `test_conv_reg` to cover all 16 nibble values, and adds an end-to-end test (`load_imm` with the destination register nibble flipped 12 → 15, asserting the value lands in A5 and not T2) registered via `run_tests!` so CI exercises the compiler backends.

Verified locally that `test_conv_reg` fails without the fix (T2 vs A5 native registers at the `debug_assert`) and passes with it.


Closes: #391 