### PR TITLE
Fix instantiation stalls when reusing recycled sandbox workers

### DIFF
--- a/crates/polkavm/src/config.rs
+++ b/crates/polkavm/src/config.rs
@@ -107,7 +107,7 @@ pub enum CorePinning {
     PinToCore,
     /// Automatically pin the host thread to a single CPU CCX.
     PinToCcx,
-    /// Disable automatic pinning.
+    /// Disable automatic pinning, both of the host threads and of the sandbox worker processes.
     Disabled,
 }
 

--- a/crates/polkavm/src/sandbox/linux.rs
+++ b/crates/polkavm/src/sandbox/linux.rs
@@ -1899,7 +1899,11 @@ impl super::Sandbox for Sandbox {
             let worker_ccx = mutable.per_core[worker_core].ccx_id;
             mutable.per_ccx[worker_ccx].worker_count += 1;
             mutable.per_core[worker_core].worker_count += 1;
-            let worker = mutable.per_core[worker_core].worker_cache.pop();
+            let worker_cache = &mut mutable.per_core[worker_core].worker_cache;
+            let worker = match worker_cache.iter().rposition(|worker| worker.is_idle()) {
+                Some(index) => Some(worker_cache.swap_remove(index)),
+                None => worker_cache.pop(),
+            };
 
             log::trace!("Spawning a new instance: host core = {host_core} (CCX = {host_ccx}), worker core = {worker_core} (CCX = {worker_ccx}), recycled = {}", worker.is_some());
             (host_ccx, worker_core, worker)
@@ -2624,6 +2628,13 @@ impl Sandbox {
         unsafe { &*self.vmctx_mmap.as_ptr().cast::<VmCtx>() }
     }
 
+    /// Whether the worker has finished its asynchronous recycle and is ready for reuse.
+    ///
+    /// Only a hint: `wait` still synchronizes with the worker before it is actually used.
+    fn is_idle(&self) -> bool {
+        self.vmctx().futex.load(Ordering::Relaxed) == VMCTX_FUTEX_IDLE
+    }
+
     fn wake_worker(&mut self) -> Result<(), Error> {
         self.exit_low_latency_mode();
         self.vmctx().futex.store(VMCTX_FUTEX_BUSY, Ordering::Release);
@@ -3024,10 +3035,12 @@ impl Sandbox {
         };
 
         let child_pid = child.pid;
-        if let Err(error) = pin_to_cpu(child_pid, worker_core) {
-            log::warn!("Failed to pin worker #{child_pid} to core {worker_core}: {error}");
-        } else {
-            log::trace!("Pinned worker #{child_pid} to core {worker_core}");
+        if global.core_pinning != CorePinning::Disabled {
+            if let Err(error) = pin_to_cpu(child_pid, worker_core) {
+                log::warn!("Failed to pin worker #{child_pid} to core {worker_core}: {error}");
+            } else {
+                log::trace!("Pinned worker #{child_pid} to core {worker_core}");
+            }
         }
 
         child_socket.close()?;


### PR DESCRIPTION
On a machine running more than one polkavm-using process, instantiations which reuse a recycled worker (100% cache hit rate, no spawning involved) intermittently stalled for 20-172ms instead of the usual ~60us. Observed on a parachain collator authoring blocks of contract transactions while other nodes on the same machine validated earlier blocks: every transaction boundary dropped all of its instances at once and the next transaction's first instantiation stalled, repeatedly hitting the proposal deadline with mostly-empty blocks.

Three things conspire to cause this:

* Recycling is asynchronous. `recycle()` stores `ext_recycle` into the worker's jump slot, wakes its futex and immediately pushes it into the per-core cache. The worker still needs a timeslice to actually run the reset and flip its futex back to idle; nobody waits for that. The *next* acquirer does, in the blocking `wait()` right after taking a worker out of the cache.

* The cache is popped LIFO. The most recently recycled worker is exactly the one least likely to have been scheduled yet, and dropping a batch of instances followed by an immediate instantiation (the transaction-boundary pattern above) makes hitting a mid-reset worker the common case rather than a rare race.

* Workers are unconditionally pinned to a single core. `CorePinning::Disabled` only ever disabled pinning of the host threads; `spawn_new_worker` pinned the worker regardless. The worker core is chosen from the engine's own per-core bookkeeping, lowest index first, and that bookkeeping is blind to everything outside the engine: other processes' engines run the same deterministic selection and pile their workers onto the same low-numbered cores, and the kernel schedules everyone's ordinary threads there as well. On topologies without SMT and with a single cache domain the hyperthread/CCX preference tiers degenerate, so this becomes "every engine pins to the lowest few cores". A mid-reset worker captive to one oversubscribed runqueue then cannot reset for tens of milliseconds while other cores sit idle -- and the host blocks on it for that whole time.

Two changes:

* When taking a worker from a core's cache, prefer the most recently recycled worker whose futex already reads idle and only fall back to the newest one otherwise. The scan is confined to the chosen core's cache, where every worker is pinned to the same core, so it composes with core pinning; and whenever the newest worker has already finished its reset (the common case on an uncontended machine) it picks the same worker as the old `pop()` did. It only deviates when popping would have meant blocking on a worker that cannot run yet. The idle check is a relaxed-load hint; `wait()` still synchronizes with the worker before it is used.

* Respect `CorePinning::Disabled` for the worker processes too. With pinning disabled the kernel is free to schedule a resetting worker on any idle core, which removes the stall at its root for deployments where several engines share a machine. The per-core cache structure is unaffected: the worker's assigned core remains the cache key; it just no longer carries an affinity.
