### PR TITLE
Allow configuring the `LineProgram` per-region instruction limit and relax sanity check

### DIFF
--- a/crates/polkavm-common/src/program.rs
+++ b/crates/polkavm-common/src/program.rs
@@ -6159,6 +6159,11 @@ struct LineProgramFrame {
     column: u32,
 }
 
+/// The maximum number of line program opcodes parsed for a single region.
+///
+/// Producers of the debug line program must keep every region within this limit.
+pub const INSTRUCTION_LIMIT_PER_REGION: usize = 512;
+
 /// A line program state machine.
 pub struct LineProgram<'a> {
     entry_index: usize,
@@ -6208,9 +6213,6 @@ impl<'a> LineProgram<'a> {
         if self.is_finished {
             return Ok(None);
         }
-
-        // Put an upper limit to how many instructions we'll process.
-        const INSTRUCTION_LIMIT_PER_REGION: usize = 512;
 
         let mark_as_finished_on_drop = SetTrueOnDrop(&mut self.is_finished);
         for _ in 0..INSTRUCTION_LIMIT_PER_REGION {

--- a/crates/polkavm-common/src/program.rs
+++ b/crates/polkavm-common/src/program.rs
@@ -5778,7 +5778,7 @@ impl ProgramBlob {
 
                         self.iteration_limit -= 1;
 
-                        let Ok(Some(region_info)) = line_program.raw_run() else {
+                        let Ok(Some(region_info)) = line_program.raw_run(INSTRUCTION_LIMIT_PER_REGION) else {
                             self.iteration_limit = 0;
                             return None;
                         };
@@ -6159,10 +6159,27 @@ struct LineProgramFrame {
     column: u32,
 }
 
-/// The maximum number of line program opcodes parsed for a single region.
-///
-/// Producers of the debug line program must keep every region within this limit.
+/// The default maximum number of line program opcodes parsed for a single region.
 pub const INSTRUCTION_LIMIT_PER_REGION: usize = 512;
+
+/// A configuration for how a [`LineProgram`] is run.
+#[derive(Clone, Copy, Debug)]
+#[non_exhaustive]
+pub struct LineProgramConfig {
+    /// The maximum number of line program opcodes parsed for a single region.
+    ///
+    /// Parsing fails once a region exceeds this many opcodes, which bounds the work
+    /// a single region can trigger. Set it to [`usize::MAX`] to disable the limit.
+    pub instruction_limit_per_region: usize,
+}
+
+impl Default for LineProgramConfig {
+    fn default() -> Self {
+        LineProgramConfig {
+            instruction_limit_per_region: INSTRUCTION_LIMIT_PER_REGION,
+        }
+    }
+}
 
 /// A line program state machine.
 pub struct LineProgram<'a> {
@@ -6186,7 +6203,13 @@ impl<'a> LineProgram<'a> {
 
     /// Runs the line program until the next region becomes available, or until the program ends.
     pub fn run(&mut self) -> Result<Option<RegionInfo>, ProgramParseError> {
-        match self.raw_run() {
+        self.run_with_config(LineProgramConfig::default())
+    }
+
+    /// Runs the line program until the next region becomes available, or until the program ends,
+    /// using the provided `config` to control how the program is parsed.
+    pub fn run_with_config(&mut self, config: LineProgramConfig) -> Result<Option<RegionInfo>, ProgramParseError> {
+        match self.raw_run(config.instruction_limit_per_region) {
             Ok(Some(region_info)) => Ok(Some(self.convert_region_info(region_info))),
             Ok(None) => Ok(None),
             Err(error) => Err(error),
@@ -6202,7 +6225,7 @@ impl<'a> LineProgram<'a> {
         }
     }
 
-    fn raw_run(&mut self) -> Result<Option<RawRegionInfo>, ProgramParseError> {
+    fn raw_run(&mut self, instruction_limit_per_region: usize) -> Result<Option<RawRegionInfo>, ProgramParseError> {
         struct SetTrueOnDrop<'a>(&'a mut bool);
         impl<'a> Drop for SetTrueOnDrop<'a> {
             fn drop(&mut self) {
@@ -6215,7 +6238,7 @@ impl<'a> LineProgram<'a> {
         }
 
         let mark_as_finished_on_drop = SetTrueOnDrop(&mut self.is_finished);
-        for _ in 0..INSTRUCTION_LIMIT_PER_REGION {
+        for _ in 0..instruction_limit_per_region {
             let byte = match self.reader.read_byte() {
                 Ok(byte) => byte,
                 Err(error) => {
@@ -6361,6 +6384,59 @@ impl<'a> LineProgram<'a> {
             "found a line program with too many instructions",
         )))
     }
+}
+
+#[test]
+fn test_default_line_program_config_uses_the_constant_limit() {
+    assert_eq!(
+        LineProgramConfig::default().instruction_limit_per_region,
+        INSTRUCTION_LIMIT_PER_REGION
+    );
+}
+
+#[cfg(feature = "alloc")]
+#[test]
+fn test_run_with_config_can_raise_the_instruction_limit() {
+    // One region padded with exactly the default budget of non-finishing opcodes, so its
+    // finishing opcode falls just past the budget and the default parse should give up.
+    let mut line_programs = alloc::vec![VERSION_DEBUG_LINE_PROGRAM_V1];
+    for _ in 0..INSTRUCTION_LIMIT_PER_REGION {
+        line_programs.push(LineProgramOp::IncrementLine as u8);
+    }
+    line_programs.push(LineProgramOp::FinishInstruction as u8);
+    line_programs.push(LineProgramOp::FinishProgram as u8);
+
+    // A single range entry covering program counter 0, whose program starts right after the
+    // one-byte version marker.
+    let mut ranges = alloc::vec::Vec::new();
+    ranges.extend_from_slice(&0_u32.to_le_bytes()); // program_counter_start
+    ranges.extend_from_slice(&1_u32.to_le_bytes()); // program_counter_end
+    ranges.extend_from_slice(&1_u32.to_le_bytes()); // info_offset (past the version marker)
+
+    let mut builder = crate::writer::ProgramBlobBuilder::new(InstructionSetKind::Latest64);
+    builder.set_code(&[Instruction::trap], &[]);
+    builder.add_custom_section(SECTION_OPT_DEBUG_LINE_PROGRAMS, line_programs);
+    builder.add_custom_section(SECTION_OPT_DEBUG_LINE_PROGRAM_RANGES, ranges);
+
+    let blob = ProgramBlob::parse(builder.into_vec().unwrap().into()).unwrap();
+
+    // The default limit rejects the over-long region, exactly as a runtime consumer would.
+    let mut line_program = blob.get_debug_line_program_at(ProgramCounter(0)).unwrap().unwrap();
+    let Err(error) = line_program.run() else {
+        panic!("the default limit should reject the over-long region");
+    };
+    assert!(
+        alloc::format!("{error}").contains("too many instructions"),
+        "unexpected error: {error}"
+    );
+
+    // Raising the limit lets the same region parse: one region, then the program ends.
+    let config = LineProgramConfig {
+        instruction_limit_per_region: usize::MAX,
+    };
+    let mut line_program = blob.get_debug_line_program_at(ProgramCounter(0)).unwrap().unwrap();
+    assert!(line_program.run_with_config(config).unwrap().is_some());
+    assert!(line_program.run_with_config(config).unwrap().is_none());
 }
 
 struct DisplayName<'a> {

--- a/crates/polkavm-common/src/program.rs
+++ b/crates/polkavm-common/src/program.rs
@@ -6160,7 +6160,7 @@ struct LineProgramFrame {
 }
 
 /// The default maximum number of line program opcodes parsed for a single region.
-pub const INSTRUCTION_LIMIT_PER_REGION: usize = 512;
+const INSTRUCTION_LIMIT_PER_REGION: usize = 512;
 
 /// A configuration for how a [`LineProgram`] is run.
 #[derive(Clone, Copy, Debug)]

--- a/crates/polkavm-linker/src/program_from_elf.rs
+++ b/crates/polkavm-linker/src/program_from_elf.rs
@@ -11043,18 +11043,7 @@ fn program_from_elf_internal(config: Config, isa: TargetInstructionSet, mut elf:
                 }
             }
 
-            if list.is_empty() {
-                locations_for_instruction.push(None);
-            } else if list.len() == 1 {
-                locations_for_instruction.push(list.into_iter().next())
-            } else {
-                let mut new_list = Vec::new();
-                for sublist in list {
-                    new_list.extend(sublist.iter().cloned());
-                }
-
-                locations_for_instruction.push(Some(new_list.into()));
-            }
+            locations_for_instruction.push(flatten_location_stack(list));
         }
 
         log::trace!(
@@ -11161,6 +11150,51 @@ fn simplify_path(path: &str) -> Cow<str> {
     }
 
     path.into()
+}
+
+/// The maximum number of line program opcodes [`emit_debug_info`] emits for
+/// one frame: a [`LineProgramOp::SetMutationDepth`] plus the field setters.
+const MAX_LINE_PROGRAM_OPCODES_PER_FRAME: usize = 7;
+
+/// The line program opcodes in one instruction's region that are not per-frame:
+/// a leading [`LineProgramOp::SetStackDepth`] and a trailing finish op.
+const LINE_PROGRAM_OPCODES_PER_INSTRUCTION_OVERHEAD: usize = 2;
+
+/// The maximum number of inline frames recorded for a single instruction.
+///
+/// One machine instruction can be attributed to many source locations at once
+/// (e.g. when identical code from several call sites is merged), and each
+/// contributes its whole inline-frame stack. Left unbounded the merged stack
+/// can grow arbitrarily deep, and since [`emit_debug_info`] emits per-frame ops
+/// with no intervening finish op, a deep stack yields a region the runtime
+/// parser refuses to read.
+///
+/// The value is derived from the parser's per-region budget so a capped
+/// instruction always fits in one region.
+const MAX_FRAMES_PER_INSTRUCTION: usize =
+    (program::INSTRUCTION_LIMIT_PER_REGION - LINE_PROGRAM_OPCODES_PER_INSTRUCTION_OVERHEAD) / MAX_LINE_PROGRAM_OPCODES_PER_FRAME;
+
+/// Merges the per-source inline-frame stacks gathered for one instruction into a
+/// single stack, capping it at [`MAX_FRAMES_PER_INSTRUCTION`] frames.
+///
+/// Returns `None` when there is no location information. The outermost frames are kept.
+fn flatten_location_stack(list: Vec<Arc<[Location]>>) -> Option<Arc<[Location]>> {
+    if list.is_empty() {
+        return None;
+    }
+
+    // Fast path: a lone stack that already fits is reused without copying.
+    if list.len() == 1 && list[0].len() <= MAX_FRAMES_PER_INSTRUCTION {
+        return list.into_iter().next();
+    }
+
+    Some(
+        list.iter()
+            .flat_map(|sublist| sublist.iter())
+            .take(MAX_FRAMES_PER_INSTRUCTION)
+            .cloned()
+            .collect(),
+    )
 }
 
 fn emit_debug_info(
@@ -11541,4 +11575,105 @@ fn emit_debug_info(
     builder.add_custom_section(program::SECTION_OPT_DEBUG_STRINGS, dbg_strings.section);
     builder.add_custom_section(program::SECTION_OPT_DEBUG_LINE_PROGRAMS, section_line_programs);
     builder.add_custom_section(program::SECTION_OPT_DEBUG_LINE_PROGRAM_RANGES, section_line_program_ranges);
+}
+
+#[cfg(test)]
+mod test_debug_line_program {
+    use super::*;
+    use crate::dwarf::SourceCodeLocation;
+    use polkavm_common::program::ProgramParseError;
+
+    /// Creates a maximally verbose frame: every field is distinct, so each frame
+    /// forces [`emit_debug_info`] to emit the full set of line program ops.
+    fn create_location(depth: u32) -> Location {
+        Location {
+            kind: if (depth & 1) == 0 { FrameKind::Enter } else { FrameKind::Call },
+            namespace: Some(format!("ns{depth}").into()),
+            function_name: Some(format!("fn{depth}").into()),
+            source_code_location: Some(SourceCodeLocation::Column {
+                path: format!("f{depth}.rs").into(),
+                line: depth,
+                column: depth,
+            }),
+        }
+    }
+
+    /// Creates a stack of one frame at the given depth.
+    fn create_single_frame_stack(depth: u32) -> Arc<[Location]> {
+        [create_location(depth)].into()
+    }
+
+    #[test]
+    fn test_flatten_location_stack_caps_deep_stacks() {
+        let less_than_max_frames: u32 = 3;
+        let more_than_max_frames = MAX_FRAMES_PER_INSTRUCTION.saturating_add(50) as u32;
+
+        // No location information yields no stack.
+        assert!(flatten_location_stack(Vec::new()).is_none());
+
+        // A single stack within the cap is kept as-is.
+        let one_stack_with_few_frames: Vec<Arc<[Location]>> = vec![(0..less_than_max_frames).map(create_location).collect()];
+        assert_eq!(
+            flatten_location_stack(one_stack_with_few_frames).unwrap().len(),
+            less_than_max_frames as usize
+        );
+
+        // A single stack over the cap is truncated.
+        let one_stack_with_many_frames: Vec<Arc<[Location]>> = vec![(0..more_than_max_frames).map(create_location).collect()];
+        assert_eq!(
+            flatten_location_stack(one_stack_with_many_frames).unwrap().len(),
+            MAX_FRAMES_PER_INSTRUCTION
+        );
+
+        // Many stacks are concatenated and capped, keeping the outermost frames in order.
+        let many_stacks_with_one_frame: Vec<Arc<[Location]>> = (0..more_than_max_frames).map(create_single_frame_stack).collect();
+        let flattened_stack = flatten_location_stack(many_stacks_with_one_frame).unwrap();
+        assert_eq!(flattened_stack.len(), MAX_FRAMES_PER_INSTRUCTION);
+        assert_eq!(flattened_stack[0].source_code_location.as_ref().unwrap().line(), Some(0));
+        assert_eq!(flattened_stack[1].source_code_location.as_ref().unwrap().line(), Some(1));
+    }
+
+    /// Attributes `stack` to one instruction, emits the debug info, and walks the
+    /// resulting line program, surfacing any parse error.
+    fn emit_and_parse(stack: Arc<[Location]>) -> Result<(), ProgramParseError> {
+        let mut builder = ProgramBlobBuilder::new(InstructionSetKind::Latest64);
+        builder.set_code(&[Instruction::fallthrough, Instruction::fallthrough], &[]);
+
+        let blob = ProgramBlob::parse(builder.to_vec().unwrap().into()).unwrap();
+        let offsets: Vec<(ProgramCounter, ProgramCounter)> = blob
+            .instructions()
+            .map(|instruction| (instruction.offset, instruction.next_offset))
+            .collect();
+        assert!(!offsets.is_empty());
+
+        let mut locations: Vec<Option<Arc<[Location]>>> = vec![None; offsets.len()];
+        locations[0] = Some(stack);
+
+        emit_debug_info(&mut builder, &locations, &offsets);
+
+        let blob = ProgramBlob::parse(builder.to_vec().unwrap().into()).unwrap();
+        let mut line_program = blob.get_debug_line_program_at(offsets[0].0)?.unwrap();
+        while line_program.run()?.is_some() {}
+
+        Ok(())
+    }
+
+    #[test]
+    fn test_deep_frame_stack_emits_parseable_line_program() {
+        let more_than_max_frames = MAX_FRAMES_PER_INSTRUCTION.saturating_add(50) as u32;
+
+        // Without the cap a deep stack overflows the parser's per-region limit.
+        let deep_stack: Arc<[Location]> = (0..more_than_max_frames).map(create_location).collect();
+        let error = emit_and_parse(Arc::clone(&deep_stack)).expect_err("an over-deep stack should overflow the region");
+        assert!(
+            error.to_string().contains("too many instructions"),
+            "unexpected parse error: {error}"
+        );
+
+        // Capping it via `flatten_location_stack` keeps the line program parseable,
+        // even with maximally verbose frames.
+        let capped = flatten_location_stack(vec![deep_stack]).unwrap();
+        assert_eq!(capped.len(), MAX_FRAMES_PER_INSTRUCTION);
+        assert!(emit_and_parse(capped).is_ok());
+    }
 }

--- a/crates/polkavm-linker/src/program_from_elf.rs
+++ b/crates/polkavm-linker/src/program_from_elf.rs
@@ -2,8 +2,8 @@
 use polkavm_common::abi::{MemoryMapBuilder, VM_CODE_ADDRESS_ALIGNMENT, VM_MAX_PAGE_SIZE, VM_MIN_PAGE_SIZE};
 use polkavm_common::cast::cast;
 use polkavm_common::program::{
-    self, FrameKind, Instruction, InstructionFormat, InstructionSet, InstructionSetKind, LineProgramOp, Opcode, ProgramBlob,
-    ProgramCounter, ProgramSymbol,
+    self, FrameKind, Instruction, InstructionFormat, InstructionSet, InstructionSetKind, LineProgramConfig, LineProgramOp, Opcode,
+    ProgramBlob, ProgramCounter, ProgramSymbol,
 };
 use polkavm_common::utils::{align_to_next_page_u32, align_to_next_page_u64};
 use polkavm_common::varint;
@@ -11043,7 +11043,18 @@ fn program_from_elf_internal(config: Config, isa: TargetInstructionSet, mut elf:
                 }
             }
 
-            locations_for_instruction.push(flatten_location_stack(list));
+            if list.is_empty() {
+                locations_for_instruction.push(None);
+            } else if list.len() == 1 {
+                locations_for_instruction.push(list.into_iter().next())
+            } else {
+                let mut new_list = Vec::new();
+                for sublist in list {
+                    new_list.extend(sublist.iter().cloned());
+                }
+
+                locations_for_instruction.push(Some(new_list.into()));
+            }
         }
 
         log::trace!(
@@ -11087,6 +11098,11 @@ fn program_from_elf_internal(config: Config, isa: TargetInstructionSet, mut elf:
 
     // Sanity check that our debug info was properly emitted and can be parsed.
     if cfg!(debug_assertions) && !config.strip {
+        // Raise/disable the per-region limit so the check never rejects valid output.
+        // A deeply inlined instruction could produce a region with more opcodes than the default allows.
+        let mut line_program_config = LineProgramConfig::default();
+        line_program_config.instruction_limit_per_region = usize::MAX;
+
         'outer: for (nth_instruction, locations) in locations_for_instruction.iter().enumerate() {
             let (program_counter, _) = offsets[nth_instruction];
             let line_program = blob.get_debug_line_program_at(program_counter).unwrap();
@@ -11096,7 +11112,7 @@ fn program_from_elf_internal(config: Config, isa: TargetInstructionSet, mut elf:
             };
 
             let mut line_program = line_program.unwrap();
-            while let Some(region_info) = line_program.run().unwrap() {
+            while let Some(region_info) = line_program.run_with_config(line_program_config).unwrap() {
                 if !region_info.instruction_range().contains(&program_counter) {
                     continue;
                 }
@@ -11150,51 +11166,6 @@ fn simplify_path(path: &str) -> Cow<str> {
     }
 
     path.into()
-}
-
-/// The maximum number of line program opcodes [`emit_debug_info`] emits for
-/// one frame: a [`LineProgramOp::SetMutationDepth`] plus the field setters.
-const MAX_LINE_PROGRAM_OPCODES_PER_FRAME: usize = 7;
-
-/// The line program opcodes in one instruction's region that are not per-frame:
-/// a leading [`LineProgramOp::SetStackDepth`] and a trailing finish op.
-const LINE_PROGRAM_OPCODES_PER_INSTRUCTION_OVERHEAD: usize = 2;
-
-/// The maximum number of inline frames recorded for a single instruction.
-///
-/// One machine instruction can be attributed to many source locations at once
-/// (e.g. when identical code from several call sites is merged), and each
-/// contributes its whole inline-frame stack. Left unbounded the merged stack
-/// can grow arbitrarily deep, and since [`emit_debug_info`] emits per-frame ops
-/// with no intervening finish op, a deep stack yields a region the runtime
-/// parser refuses to read.
-///
-/// The value is derived from the parser's per-region budget so a capped
-/// instruction always fits in one region.
-const MAX_FRAMES_PER_INSTRUCTION: usize =
-    (program::INSTRUCTION_LIMIT_PER_REGION - LINE_PROGRAM_OPCODES_PER_INSTRUCTION_OVERHEAD) / MAX_LINE_PROGRAM_OPCODES_PER_FRAME;
-
-/// Merges the per-source inline-frame stacks gathered for one instruction into a
-/// single stack, capping it at [`MAX_FRAMES_PER_INSTRUCTION`] frames.
-///
-/// Returns `None` when there is no location information. The outermost frames are kept.
-fn flatten_location_stack(list: Vec<Arc<[Location]>>) -> Option<Arc<[Location]>> {
-    if list.is_empty() {
-        return None;
-    }
-
-    // Fast path: a lone stack that already fits is reused without copying.
-    if list.len() == 1 && list[0].len() <= MAX_FRAMES_PER_INSTRUCTION {
-        return list.into_iter().next();
-    }
-
-    Some(
-        list.iter()
-            .flat_map(|sublist| sublist.iter())
-            .take(MAX_FRAMES_PER_INSTRUCTION)
-            .cloned()
-            .collect(),
-    )
 }
 
 fn emit_debug_info(
@@ -11581,7 +11552,7 @@ fn emit_debug_info(
 mod test_debug_line_program {
     use super::*;
     use crate::dwarf::SourceCodeLocation;
-    use polkavm_common::program::ProgramParseError;
+    use polkavm_common::program::{LineProgramConfig, ProgramParseError};
 
     /// Creates a maximally verbose frame: every field is distinct, so each frame
     /// forces [`emit_debug_info`] to emit the full set of line program ops.
@@ -11598,44 +11569,9 @@ mod test_debug_line_program {
         }
     }
 
-    /// Creates a stack of one frame at the given depth.
-    fn create_single_frame_stack(depth: u32) -> Arc<[Location]> {
-        [create_location(depth)].into()
-    }
-
-    #[test]
-    fn test_flatten_location_stack_caps_deep_stacks() {
-        let less_than_max_frames: u32 = 3;
-        let more_than_max_frames = MAX_FRAMES_PER_INSTRUCTION.saturating_add(50) as u32;
-
-        // No location information yields no stack.
-        assert!(flatten_location_stack(Vec::new()).is_none());
-
-        // A single stack within the cap is kept as-is.
-        let one_stack_with_few_frames: Vec<Arc<[Location]>> = vec![(0..less_than_max_frames).map(create_location).collect()];
-        assert_eq!(
-            flatten_location_stack(one_stack_with_few_frames).unwrap().len(),
-            less_than_max_frames as usize
-        );
-
-        // A single stack over the cap is truncated.
-        let one_stack_with_many_frames: Vec<Arc<[Location]>> = vec![(0..more_than_max_frames).map(create_location).collect()];
-        assert_eq!(
-            flatten_location_stack(one_stack_with_many_frames).unwrap().len(),
-            MAX_FRAMES_PER_INSTRUCTION
-        );
-
-        // Many stacks are concatenated and capped, keeping the outermost frames in order.
-        let many_stacks_with_one_frame: Vec<Arc<[Location]>> = (0..more_than_max_frames).map(create_single_frame_stack).collect();
-        let flattened_stack = flatten_location_stack(many_stacks_with_one_frame).unwrap();
-        assert_eq!(flattened_stack.len(), MAX_FRAMES_PER_INSTRUCTION);
-        assert_eq!(flattened_stack[0].source_code_location.as_ref().unwrap().line(), Some(0));
-        assert_eq!(flattened_stack[1].source_code_location.as_ref().unwrap().line(), Some(1));
-    }
-
     /// Attributes `stack` to one instruction, emits the debug info, and walks the
-    /// resulting line program, surfacing any parse error.
-    fn emit_and_parse(stack: Arc<[Location]>) -> Result<(), ProgramParseError> {
+    /// resulting line program with `config`, surfacing any parse error.
+    fn emit_and_parse(stack: Arc<[Location]>, config: LineProgramConfig) -> Result<(), ProgramParseError> {
         let mut builder = ProgramBlobBuilder::new(InstructionSetKind::Latest64);
         builder.set_code(&[Instruction::fallthrough, Instruction::fallthrough], &[]);
 
@@ -11653,27 +11589,30 @@ mod test_debug_line_program {
 
         let blob = ProgramBlob::parse(builder.to_vec().unwrap().into()).unwrap();
         let mut line_program = blob.get_debug_line_program_at(offsets[0].0)?.unwrap();
-        while line_program.run()?.is_some() {}
+        while line_program.run_with_config(config)?.is_some() {}
 
         Ok(())
     }
 
     #[test]
-    fn test_deep_frame_stack_emits_parseable_line_program() {
-        let more_than_max_frames = MAX_FRAMES_PER_INSTRUCTION.saturating_add(50) as u32;
+    fn test_deep_frame_stack_parses_only_when_the_limit_is_raised() {
+        let default_config = LineProgramConfig::default();
 
-        // Without the cap a deep stack overflows the parser's per-region limit.
-        let deep_stack: Arc<[Location]> = (0..more_than_max_frames).map(create_location).collect();
-        let error = emit_and_parse(Arc::clone(&deep_stack)).expect_err("an over-deep stack should overflow the region");
+        // Use as many frames as the default per-region opcode budget. Each frame emits
+        // several opcodes, so the region's opcode count far exceeds the default limit.
+        let deep_frame_count = default_config.instruction_limit_per_region as u32;
+        let deep_stack: Arc<[Location]> = (0..deep_frame_count).map(create_location).collect();
+
+        let error = emit_and_parse(Arc::clone(&deep_stack), default_config)
+            .expect_err("a region with more opcodes than the default limit should fail to parse");
         assert!(
             error.to_string().contains("too many instructions"),
             "unexpected parse error: {error}"
         );
 
-        // Capping it via `flatten_location_stack` keeps the line program parseable,
-        // even with maximally verbose frames.
-        let capped = flatten_location_stack(vec![deep_stack]).unwrap();
-        assert_eq!(capped.len(), MAX_FRAMES_PER_INSTRUCTION);
-        assert!(emit_and_parse(capped).is_ok());
+        // With the limit raised/disabled, the whole region parses.
+        let mut config_no_limit = default_config;
+        config_no_limit.instruction_limit_per_region = usize::MAX;
+        assert!(emit_and_parse(deep_stack, config_no_limit).is_ok());
     }
 }

--- a/crates/polkavm/src/lib.rs
+++ b/crates/polkavm/src/lib.rs
@@ -128,7 +128,7 @@ pub use polkavm_common::{
 
 /// Miscellaneous types related to debug info.
 pub mod debug_info {
-    pub use polkavm_common::program::{FrameInfo, FrameKind, LineProgram, RegionInfo, SourceLocation};
+    pub use polkavm_common::program::{FrameInfo, FrameKind, LineProgram, LineProgramConfig, RegionInfo, SourceLocation};
 
     #[cfg(feature = "std")]
     pub use crate::source_cache::SourceCache;


### PR DESCRIPTION
## Description

`program_from_elf` can emit a debug line program that the runtime parser refuses to read. A debug build panics in the linker's own sanity check:

```
thread 'main' panicked at program_from_elf.rs:
called `Result::unwrap()` on an `Err` value: ProgramParseError(Other("found a line program with too many instructions"))
```

A release build does not panic (the check is gated on `cfg!(debug_assertions) && !config.strip`) but still emits a region no consumer can parse, so backtraces for that region fail.

The line program parser (`LineProgram::raw_run`) reads at most `INSTRUCTION_LIMIT_PER_REGION` (512) opcodes per region. For one instruction, `emit_debug_info` writes a `SetStackDepth`, then up to seven opcodes per inline frame, and only then the finish op that ends the region. So a single instruction with a deep enough inline-frame stack produces a region over the limit.

This was [reported](https://github.com/paritytech/revive/issues/574) in revive when compiling using a debug build which panicked in the polkavm linker.

## Changes

The parser's instruction limit per region is made configurable instead so the sanity check can relax it:

* `struct LineProgramConfig`
  * New config with a `Default` keeping the prior hardcoded limit.
  * Raising it to `usize::MAX` essentially disables it.
* `fn LineProgram::run_with_config()`
  * `run()` delegates to it with `LineProgramConfig::default()`.
* Sanity check in `program_from_elf`
  * Runs with the limit max raised/disabled.

(This has been updated from the previous approach of capping the frame stack per instruction as per review feedback)