### PR TITLE
added: +unaligned-scalar-mem

### DIFF
--- a/crates/polkavm-linker/targets/1_91/riscv32emac-unknown-none-polkavm.json
+++ b/crates/polkavm-linker/targets/1_91/riscv32emac-unknown-none-polkavm.json
@@ -5,7 +5,7 @@
   "data-layout": "e-m:e-p:32:32-i64:64-n32-S32",
   "eh-frame-header": false,
   "emit-debug-gdb-scripts": false,
-  "features": "+e,+m,+a,+c,+zbb,+auipc-addi-fusion,+ld-add-fusion,+lui-addi-fusion,+xtheadcondmov",
+  "features": "+e,+m,+a,+c,+zbb,+unaligned-scalar-mem,+auipc-addi-fusion,+ld-add-fusion,+lui-addi-fusion,+xtheadcondmov",
   "linker": "rust-lld",
   "linker-flavor": "ld.lld",
   "llvm-abiname": "ilp32e",

--- a/crates/polkavm-linker/targets/1_91/riscv64emac-unknown-none-polkavm.json
+++ b/crates/polkavm-linker/targets/1_91/riscv64emac-unknown-none-polkavm.json
@@ -5,7 +5,7 @@
   "data-layout": "e-m:e-p:64:64-i64:64-i128:128-n32:64-S64",
   "eh-frame-header": false,
   "emit-debug-gdb-scripts": false,
-  "features": "+e,+m,+a,+c,+zbb,+auipc-addi-fusion,+ld-add-fusion,+lui-addi-fusion,+xtheadcondmov",
+  "features": "+e,+m,+a,+c,+zbb,+unaligned-scalar-mem,+auipc-addi-fusion,+ld-add-fusion,+lui-addi-fusion,+xtheadcondmov",
   "linker": "rust-lld",
   "linker-flavor": "ld.lld",
   "llvm-abiname": "lp64e",

--- a/crates/polkavm-linker/targets/legacy/riscv32emac-unknown-none-polkavm.json
+++ b/crates/polkavm-linker/targets/legacy/riscv32emac-unknown-none-polkavm.json
@@ -5,7 +5,7 @@
   "data-layout": "e-m:e-p:32:32-i64:64-n32-S32",
   "eh-frame-header": false,
   "emit-debug-gdb-scripts": false,
-  "features": "+e,+m,+a,+c,+zbb,+auipc-addi-fusion,+ld-add-fusion,+lui-addi-fusion,+xtheadcondmov",
+  "features": "+e,+m,+a,+c,+zbb,+unaligned-scalar-mem,+auipc-addi-fusion,+ld-add-fusion,+lui-addi-fusion,+xtheadcondmov",
   "linker": "rust-lld",
   "linker-flavor": "ld.lld",
   "llvm-abiname": "ilp32e",

--- a/crates/polkavm-linker/targets/legacy/riscv64emac-unknown-none-polkavm.json
+++ b/crates/polkavm-linker/targets/legacy/riscv64emac-unknown-none-polkavm.json
@@ -5,7 +5,7 @@
   "data-layout": "e-m:e-p:64:64-i64:64-i128:128-n32:64-S64",
   "eh-frame-header": false,
   "emit-debug-gdb-scripts": false,
-  "features": "+e,+m,+a,+c,+zbb,+auipc-addi-fusion,+ld-add-fusion,+lui-addi-fusion,+xtheadcondmov",
+  "features": "+e,+m,+a,+c,+zbb,+unaligned-scalar-mem,+auipc-addi-fusion,+ld-add-fusion,+lui-addi-fusion,+xtheadcondmov",
   "linker": "rust-lld",
   "linker-flavor": "ld.lld",
   "llvm-abiname": "lp64e",


### PR DESCRIPTION
LLVM assumed unaligned loads trap on this target (the RISC-V default), so every potentially-unaligned u64/u32 read — e.g. reading words out of a &[u8] — was compiled into per-byte loads glued together with shifts and ors. PolkaVM executes unaligned accesses natively. Declaring +unaligned-scalar-mem lets LLVM emit single loads instead.

Measured on the hashing benchmarks (#409) (64-bit, recompiler, sync gas): blake2b −24%, xxhash −64%, keccak/sha2 −9% runtime at bulk input sizes.